### PR TITLE
[Feat] add 'filter' variant for board filter tags #11

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,11 +1,20 @@
-import { ButtonHTMLAttributes, ReactNode } from 'react';
+import { ButtonHTMLAttributes, ReactNode, MouseEvent } from 'react';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'secondary' | 'outline' | 'ghost' | 'text' | 'plain';
+  variant?:
+    | 'primary'
+    | 'secondary'
+    | 'outline'
+    | 'ghost'
+    | 'text'
+    | 'plain'
+    | 'filter';
   size?: 'sm' | 'md' | 'lg';
   fullWidth?: boolean;
   icon?: ReactNode;
   iconPosition?: 'left' | 'right';
+  active?: boolean;
+  onActiveChange?: (next: boolean) => void;
   children: ReactNode;
 }
 
@@ -17,6 +26,10 @@ export default function Button({
   iconPosition = 'left',
   disabled,
   className = '',
+  active = false,
+  onActiveChange,
+  onClick,
+  type,
   children,
   ...props
 }: ButtonProps) {
@@ -34,38 +47,55 @@ export default function Button({
         return 'bg-white text-grey-900 border border-grey-200 hover:bg-grey-100 disabled:opacity-50';
       case 'ghost':
         return 'bg-transparent text-grey-900 hover:bg-grey-100 disabled:opacity-50';
+      case 'filter':
+        return active
+          ? 'bg-grey-900 text-white border border-grey-900 hover:bg-grey-800 disabled:opacity-50 px-4 py-2 body-xs font-medium'
+          : 'bg-white text-grey-900 border border-grey-300 hover:bg-grey-100 disabled:opacity-50 px-4 py-2 body-xs font-medium';
       default:
         return '';
     }
   };
 
   const getSizeClasses = () => {
+    if (variant === 'filter') return '';
     switch (size) {
       case 'sm':
         return 'px-3 py-2 body-xs font-medium'; // 12px, Medium
       case 'md':
-        return 'px-8 py-2 body-sm font-medium'; // 14px, Medium
+        return 'px-4 py-2 body-sm font-medium'; // 14px, Medium
       case 'lg':
-        return 'px-20 py-2 body-sm font-medium'; // 14px, Medium
+        return 'px-20 py-2 body-sm font-medium'; // 14px, Medium (legacy usage)
       default:
         return '';
     }
   };
 
+  const radiusClass = variant === 'filter' ? 'rounded-[20px]' : 'rounded-[5px]';
+
+  const handleClick = (e: MouseEvent<HTMLButtonElement>) => {
+    if (variant === 'filter' && onActiveChange) {
+      onActiveChange(!active);
+    }
+    onClick?.(e);
+  };
+
   return (
     <button
+      type={type ?? 'button'}
       disabled={disabled}
+      aria-pressed={variant === 'filter' ? !!active : undefined}
       className={`
-        rounded-[5px]
+        ${radiusClass}
         font-body
-        inline-flex items-center justify-center gap-1
-        transition-colors
+        inline-flex items-center justify-center gap-2
+        transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500
         disabled:cursor-not-allowed
         ${getVariantClasses()}
         ${getSizeClasses()}
         ${fullWidth ? 'w-full' : ''}
         ${className}
       `}
+      onClick={handleClick}
       {...props}
     >
       {icon && iconPosition === 'left' && icon}


### PR DESCRIPTION
## 📋 작업 내용
- 게시판 필터 버튼 variant('filter') 추가
- padding/타이포 라인하이트 조정
- border-radius 20px 적용
- active/inactive 상태 및 aria-pressed 지원

### ✅ 관련 이슈
Closes #11 

## 🎯 관련 이슈
Closes #11 

## 📝 변경사항
- Button.tsx 'filter' variant


## 📸 스크린샷
<img width="302" height="86" alt="Screenshot 2025-10-10 at 23 36 15" src="https://github.com/user-attachments/assets/5a7bd8fd-a630-4e3d-b63b-44680a774234" />
