### PR TITLE
[Feat] Add Dark Mode Tokens, Utilities and Global Application

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,17 +4,28 @@ html,
 body {
   height: 100%;
   overflow-x: hidden; /* 가로 스크롤 방지 */
+  background-color: var(--color-dark-bg);
+  color: var(--color-dark-text);
 }
 
 body {
   font-family: var(--font-body);
   font-size: 1rem;
   line-height: 1.625rem;
-  background-color: var(--color-office-bg);
-  color: var(--color-office-text);
 }
 
 @theme {
+  /* Light mode tokens */
+  --color-grey-100: hsl(0 0% 96%);
+  --color-grey-200: hsl(0 0% 90%);
+  --color-grey-300: hsl(0 0% 80%);
+  --color-grey-500: hsl(0 0% 60%);
+  --color-grey-700: hsl(0 0% 40%);
+  --color-grey-900: hsl(0 0% 10%);
+  --color-primary: hsl(220 90% 56%);
+  --color-primary-dark: hsl(220 90% 46%);
+  --color-primary-light: hsl(220 90% 66%);
+
   --color-primary-100: hsl(207 100% 93%);
   --color-primary-500: hsl(212 100% 60%);
   --color-primary-900: hsl(216 65% 20%);
@@ -39,11 +50,6 @@ body {
   --color-white: hsl(0 0% 100%);
   --color-black: hsl(0 0% 0%);
 
-  --color-office-bg: var(--color-white);
-  --color-office-text: var(--color-grey-900);
-  --color-office-border: var(--color-grey-200);
-  --color-office-subtle: var(--color-grey-100);
-
   --color-status-holiday: var(--color-accent-green-600);
   --color-status-working: var(--color-primary-500);
   --color-status-break: var(--color-accent-orange-400);
@@ -51,8 +57,42 @@ body {
 }
 
 :root {
-  --gl-font-brand: var(--font-body, 'DNF Bit Bit v2, system-ui, sans-serif');
-  --gl-font-body: var(--font-body, 'S-Core Dream, system-ui, sans-serif');
+  /* Enable UA to pick proper default form controls & scrollbars per theme */
+  color-scheme: light dark;
+
+  /* Correct font variable wiring */
+  --gl-font-brand: var(--font-brand, 'DNF Bit Bit v2'), system-ui, sans-serif;
+  --gl-font-body: var(--font-body, 'S-Core Dream'), system-ui, sans-serif;
+
+  /* Light mode defaults */
+  --color-dark-bg: hsl(0 0% 100%);
+  --color-dark-text: hsl(0 0% 21%);
+  --color-dark-border: hsl(0 0% 92%);
+  --color-dark-subtle: hsl(210 18% 96%);
+}
+:root.dark {
+  /* Theme surface variables */
+  --color-dark-bg: hsl(0 0% 28%); /* grey-700 for body and header */
+  --color-dark-text: hsl(0 0% 96%);
+  --color-dark-border: hsl(0 0% 40%);
+  --color-dark-subtle: hsl(0 0% 14%); /* around grey-100 but for dark */
+  /* Flip core greys so existing utilities adapt in dark mode */
+  --color-grey-100: hsl(0 0% 14%); /* light-mode 100 -> dark surface subtle */
+  --color-grey-200: hsl(0 0% 20%);
+  --color-grey-300: hsl(0 0% 28%);
+  --color-grey-500: hsl(0 0% 60%);
+  --color-grey-700: hsl(0 0% 78%);
+  --color-grey-900: hsl(0 0% 100%); /* white in dark mode */
+  /* Flip primary colors */
+  --color-primary-100: hsl(216 65% 20%); /* swap with primary-900 */
+  --color-primary-900: hsl(207 100% 93%); /* swap with primary-100 */
+}
+/* Fixed footer background token (remains the same in both light and dark mode) */
+:root {
+  --color-footer-bg: hsl(216 65% 20%);
+}
+:root.dark {
+  --color-footer-bg: hsl(216 65% 20%);
 }
 
 @layer utilities {
@@ -201,4 +241,30 @@ body {
 .brand-h5,
 .brand-h6 {
   font-family: var(--font-brand);
+}
+
+@layer utilities {
+  .bg-dark {
+    background-color: var(--color-dark-bg);
+  }
+  .text-dark {
+    color: var(--color-dark-text);
+  }
+  .border-dark {
+    border-color: var(--color-dark-border);
+  }
+  .bg-dark-subtle {
+    background-color: var(--color-dark-subtle);
+  }
+
+  /* Fixed colors that don't change with theme */
+  .gl-bg-banner {
+    background-color: hsl(0 0% 21%);
+  }
+  .gl-text-footer {
+    color: hsl(0 0% 100%);
+  }
+  .gl-bg-footer {
+    background-color: var(--color-footer-bg);
+  }
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -8,12 +8,17 @@ import { auth } from '@/lib/supabase';
 import Image from 'next/image';
 import Input from '@/components/ui/Input';
 import Button from '@/components/ui/Button';
+import { Icon } from '@iconify/react';
 
 const loginSchema = z.object({
   email: z
     .string()
-    .min(1, '아이디를 입력하세요')
-    .regex(/^[a-z0-9]+$/, '아이디는 영문 소문자와 숫자만 입력 가능합니다'),
+    .min(3, '아이디는 3자 이상이어야 합니다')
+    .max(20, '아이디는 20자 이하여야 합니다')
+    .regex(
+      /^[a-z0-9_-]+$/,
+      '아이디는 영문 소문자, 숫자, 언더스코어(_), 하이픈(-)만 가능합니다'
+    ),
   password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다'),
 });
 
@@ -32,6 +37,7 @@ export default function LoginPage() {
     resolver: zodResolver(loginSchema),
   });
 
+  // TODO: 아이디(username) → 이메일 매핑 로직이 필요할 수도 있음.
   const onSubmit = async (data: LoginForm) => {
     setIsLoading(true);
     const { error } = await auth.signIn(data.email, data.password);
@@ -43,9 +49,9 @@ export default function LoginPage() {
   };
 
   return (
-    <>
+    <div className="relative flex flex-col flex-1">
       {/* 배경 이미지 */}
-      <div className="fixed inset-0 -z-10">
+      <div className="fixed inset-0 z-0 pointer-events-none select-none">
         <Image
           src="/images/login-background.jpg"
           alt="login background"
@@ -56,7 +62,24 @@ export default function LoginPage() {
         />
       </div>
 
-      <div className="w-full flex-1 flex items-center justify-center p-4">
+      {/* 뒤로가기 버튼 */}
+      <div className="absolute top-0 left-0 z-30 w-full">
+        <div className="app-container py-3">
+          <button
+            onClick={() => router.back()}
+            className="flex items-center justify-center w-10 h-10 rounded-lg text-white hover:bg-white/10 transition-colors"
+            aria-label="뒤로가기"
+          >
+            <Icon
+              icon="material-symbols:arrow-back-ios-rounded"
+              className="w-6 h-6"
+            />
+          </button>
+        </div>
+      </div>
+
+      {/* 로그인 폼 */}
+      <div className="relative z-10 flex-1 flex items-center justify-center p-4">
         <div
           className="w-80 p-6 flex flex-col relative"
           style={{
@@ -65,7 +88,7 @@ export default function LoginPage() {
             boxShadow: '4px 4px 4px 0 rgba(241, 141, 251, 0.10)',
           }}
         >
-          {/* Glassmorphism  */}
+          {/* Glassmorphism */}
           <div
             className="absolute inset-0 -z-10"
             style={{
@@ -76,9 +99,14 @@ export default function LoginPage() {
             }}
           />
 
-          <h1 className="brand-h2 font-brand text-white mb-6">로그인</h1>
+          <h1 className="brand-h2 font-brand text-white mb-6 relative z-10">
+            로그인
+          </h1>
 
-          <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="flex flex-col relative z-10"
+          >
             <div className="mb-6">
               <Input
                 {...register('email', {
@@ -87,7 +115,8 @@ export default function LoginPage() {
                 type="text"
                 inputMode="text"
                 autoComplete="username"
-                pattern="[a-z0-9]*"
+                pattern="[a-z0-9_-]*"
+                maxLength={20}
                 label="사원 아이디"
                 variant="dark"
                 placeholder="아이디를 입력하세요"
@@ -160,6 +189,6 @@ export default function LoginPage() {
           </form>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/LayoutWrapper.tsx
+++ b/src/components/LayoutWrapper.tsx
@@ -27,11 +27,16 @@ export default function LayoutWrapper({
   // 로그인/회원가입 페이지: 미니멀 레이아웃
   if (isAuthPage) {
     return (
-      <div className="min-h-dvh flex flex-col">
-        <TopBanner />
-        <Header variant="minimal" />
-        <main className="flex-1 min-h-0 flex flex-col">{children}</main>
-        <Footer />
+      <div className="relative min-h-dvh flex flex-col">
+        <div className="relative z-20">
+          <TopBanner />
+        </div>
+        <main className="relative z-10 flex-1 min-h-0 flex flex-col">
+          {children}
+        </main>
+        <div className="relative z-20">
+          <Footer />
+        </div>
       </div>
     );
   }
@@ -41,7 +46,6 @@ export default function LayoutWrapper({
     <div className="min-h-dvh flex flex-col">
       <TopBanner />
       <Header
-        variant="default"
         isLoggedIn={isLoggedIn}
         userProfile={
           isLoggedIn && user
@@ -55,7 +59,7 @@ export default function LayoutWrapper({
       />
 
       {/* Grid 컨테이너 */}
-      <div className="flex-1 min-h-0 bg-white">
+      <div className="flex-1 min-h-0">
         {/* Desktop Grid Layout */}
         <div className="hidden lg:block app-container pt-2 pb-4">
           <div className="grid grid-cols-[276px_1fr] gap-6">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,7 +3,7 @@ import IconLogo from '../ui/icons/IconLogo';
 
 export default function Footer() {
   return (
-    <footer className="w-full bg-primary-900 px-4 py-4 md:px-16 lg:px-64 flex flex-col items-center">
+    <footer className="w-full bg-[hsl(216_65%_20%)] text-white px-4 py-4 md:px-16 lg:px-64 flex flex-col items-center">
       <div className="w-full max-w-4xl flex flex-col md:flex-row items-center justify-center gap-4 md:gap-4">
         <IconLogo
           variant="en"
@@ -13,7 +13,7 @@ export default function Footer() {
           className="flex-shrink-0"
         />
 
-        <div className="text-center text-grey-100 text-12 order-last md:order-none font-body font-light flex items-center gap-2 flex-wrap justify-center">
+        <div className="text-center text-white text-12 order-last md:order-none font-body font-light flex items-center gap-2 flex-wrap justify-center">
           <span>© 2025 Goatlife All Rights Reserved</span>
           <span>|</span>
           <span>이용약관</span>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,7 +11,6 @@ interface HeaderProps {
     avatar?: string;
   };
   locale?: 'ko' | 'en';
-  variant?: 'default' | 'minimal';
   onMenuToggle?: () => void;
 }
 
@@ -19,7 +18,6 @@ export default function Header({
   isLoggedIn = false,
   userProfile,
   locale = 'ko',
-  variant = 'default',
   onMenuToggle,
 }: HeaderProps) {
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -27,45 +25,18 @@ export default function Header({
 
   const toggleTheme = () => {
     setIsDarkMode(!isDarkMode);
+    document.documentElement.classList.toggle('dark');
+    localStorage.setItem('theme', !isDarkMode ? 'dark' : 'light');
   };
-
-  const handleBack = () => {
-    router.back();
-  };
-
-  // 로그인 페이지용 미니멀 헤더
-  if (variant === 'minimal') {
-    return (
-      <header className="w-full bg-transparent">
-        <div className="app-container py-3">
-          <button
-            onClick={handleBack}
-            className="
-            flex items-center justify-center
-            w-10 h-10 rounded-lg
-            text-white hover:bg-white/10
-            transition-colors duration-200
-          "
-            aria-label="뒤로가기"
-          >
-            <Icon
-              icon="material-symbols:arrow-back-ios-rounded"
-              className="w-6 h-6"
-            />
-          </button>
-        </div>
-      </header>
-    );
-  }
 
   return (
-    <header className="w-full bg-white mt-2">
+    <header className="w-full bg-dark mt-2">
       <div className="app-container flex items-center justify-between py-3">
         <div className="flex items-center gap-3">
           {/* tablet, mobile only */}
           <button
             onClick={onMenuToggle}
-            className="lg:hidden p-2 rounded-lg text-grey-700 hover:bg-grey-100 transition-colors"
+            className="lg:hidden p-2 rounded-lg text-dark hover:bg-dark-subtle transition-colors"
             aria-label="메뉴 열기"
           >
             <Icon icon="icon-park:hamburger-button" className="w-6 h-6" />
@@ -85,7 +56,7 @@ export default function Header({
         <div className="flex items-center gap-3 md:gap-4">
           <button
             onClick={toggleTheme}
-            className="p-2 rounded-lg text-grey-500 hover:text-grey-700 hover:bg-grey-100 transition-colors duration-200"
+            className="p-2 rounded-lg text-dark hover:bg-dark-subtle transition-colors duration-200"
           >
             <Icon
               icon={isDarkMode ? 'lucide:sun' : 'lucide:moon'}
@@ -109,7 +80,7 @@ function LoginButton() {
   return (
     <button
       onClick={() => router.push('/login')}
-      className="text-grey-900 body-sm font-medium hover:text-primary-500 transition-colors duration-200 px-2 py-1"
+      className="text-dark body-sm font-medium hover:text-primary-500 transition-colors duration-200 px-2 py-1"
     >
       로그인
     </button>
@@ -123,7 +94,7 @@ function UserProfileSection({
 }) {
   return (
     <div className="flex items-center gap-2">
-      <span className="text-sm">{userProfile.name}</span>
+      <span className="text-sm text-dark">{userProfile.name}</span>
     </div>
   );
 }

--- a/src/components/layout/TopBanner.tsx
+++ b/src/components/layout/TopBanner.tsx
@@ -23,10 +23,10 @@ export default function TopBanner() {
   return (
     <div
       className="
-      w-full bg-grey-900 
+      w-full bg-[hsl(0_0%_21%)]
       flex items-center justify-center
       px-4 py-1.5
-      md:px-8 
+      md:px-8
       lg:px-16
       overflow-hidden
       relative


### PR DESCRIPTION
## 📋 작업 내용
- 다크모드 토큰(:root.dark) 정의 및 회색 팔레트 플립으로 기존 컴포넌트 스타일 유지
- 전역 유틸(.bg-dark/.text-dark/.bg-dark-subtle) 추가, body/main 테마 값 연결
- Header/Body 다크 배경(grey-700) 적용, Footer는 고정 primary-900 토큰으로 유지
- z-index 스택 표준화: 배경 z-0, main z-10, TopBanner/Footer z-20
- 이후 다크모드 대응 필요 컴포넌트는 토큰/유틸 참조로 단계적 전환 예정
- 기타 로그인 헤더 에러 fix

## 🎯 관련 이슈
Closes #

## 📝 변경사항


## ✅ 체크리스트
- [ ] 코드 리뷰 받을 준비 완료
- [ ] 테스트 완료 
- [ ] 문서 업데이트 (필요시)

## 📸 스크린샷
<img width="1418" height="969" alt="Screenshot 2025-10-22 at 23 04 51" src="https://github.com/user-attachments/assets/4c622c2a-ba99-46fd-8394-e7e0b672a249" />
