### PR TITLE
[Fix(auth)] improve login UX and session handling #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ pnpm install
 # 개발 서버 실행
 pnpm run dev
 
+### Supabase Auth 설정 (개발 환경)
+- Supabase Dashboard → Authentication → Providers → Email에서 **Enable Email provider**를 ON으로 설정하세요.
+- 개발 환경에서는 **Confirm email**을 OFF로 두고, 필요 시 Supabase SQL Editor에서 아래 쿼리로 테스트 계정을 인증 처리할 수 있습니다.
+
+```sql
+UPDATE auth.users
+SET email_confirmed_at = NOW()
+WHERE email_confirmed_at IS NULL;
+```
+
+- `setup-auth-trigger.sql` 스크립트를 실행해 회원가입 시 `profiles` 레코드가 자동으로 생성되도록 설정하세요.
+- `profiles.user_id` 컬럼에 UNIQUE 제약을 추가해 동일 사원 아이디로 중복 가입되는 것을 방지하는 것을 권장합니다.
+- Kakao OAuth를 사용하려면 Kakao Developers의 Redirect URI 목록에 아래 주소를 등록하세요.
+  - 프로덕션: `https://vdiolcxwsdpsvxpwduos.supabase.co/auth/v1/callback`
+  - 개발(로컬): `http://localhost:3000/auth/callback` (또는 실제 사용 중인 로컬 도메인)
+  - `.env.local` 파일에 `NEXT_PUBLIC_SITE_URL=https://your-domain.com` 값을 설정하면 OAuth가 해당 도메인으로 리다이렉트됩니다.
+
 ## 📁 프로젝트 구조
 
 현재 **Component-by-Type** 구조를 사용하고 있습니다. Next.js의 표준 관례를 따르며, 작은-중간 규모 프로젝트에 적합합니다.

--- a/src/app/api/auth/signout/route.ts
+++ b/src/app/api/auth/signout/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { createServerSupabase } from '@/lib/supabase/server';
+
+export async function POST() {
+  try {
+    const supabase = await createServerSupabase();
+    const { error } = await supabase.auth.signOut();
+
+    if (error) {
+      console.error('[api/auth/signout] signOut failed', {
+        code: error.code,
+        message: error.message,
+        status: error.status,
+      });
+
+      return NextResponse.json(
+        {
+          success: false,
+          message: '로그아웃 처리에 실패했습니다.',
+        },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('[api/auth/signout] unexpected error', error);
+    return NextResponse.json(
+      { success: false, message: '로그아웃 처리 중 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { createServerSupabase } from '@/lib/supabase/server';
+
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url);
+  const code = requestUrl.searchParams.get('code');
+  const redirectToParam = requestUrl.searchParams.get('redirect_to');
+  const errorDescription = requestUrl.searchParams.get('error_description');
+
+  let redirectDestination = '/';
+  if (redirectToParam) {
+    try {
+      const redirectUrl = new URL(redirectToParam, requestUrl.origin);
+      if (redirectUrl.origin === requestUrl.origin) {
+        redirectDestination = `${redirectUrl.pathname}${redirectUrl.search}${redirectUrl.hash}`;
+      }
+    } catch (error) {
+      console.error('[auth/callback] failed to parse redirect_to', error);
+    }
+  }
+
+  if (errorDescription) {
+    console.error('[auth/callback] provider error', errorDescription);
+    const loginUrl = new URL('/login', requestUrl.origin);
+    loginUrl.searchParams.set('error', 'oauth_failed');
+    return NextResponse.redirect(loginUrl);
+  }
+
+  if (!code) {
+    console.error('[auth/callback] missing auth code');
+    const loginUrl = new URL('/login', requestUrl.origin);
+    loginUrl.searchParams.set('error', 'missing_code');
+    return NextResponse.redirect(loginUrl);
+  }
+
+  const supabase = await createServerSupabase();
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error) {
+    console.error('[auth/callback] exchangeCodeForSession failed', {
+      code: error.code,
+      message: error.message,
+      status: error.status,
+    });
+    const loginUrl = new URL('/login', requestUrl.origin);
+    loginUrl.searchParams.set('error', 'session_exchange_failed');
+    return NextResponse.redirect(loginUrl);
+  }
+
+  return NextResponse.redirect(new URL(redirectDestination, requestUrl.origin));
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { brandFont, bodyFont } from '../lib/fonts';
 import Providers from '../components/Providers';
 import LayoutWrapper from '../components/LayoutWrapper';
 import './globals.css';
+import { createServerSupabase } from '@/lib/supabase/server';
+import type { User } from '@/types/user';
 
 export const metadata: Metadata = {
   title: '갓생상사 - Goatlife Inc.',
@@ -12,15 +14,67 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+async function getInitialUser(): Promise<User | null> {
+  try {
+    const supabase = await createServerSupabase();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return null;
+    }
+
+    const { data: profile, error } = await supabase
+      .from('profiles')
+      .select('last_name, first_name, avatar_url, department, rank, user_id')
+      .eq('id', user.id)
+      .maybeSingle();
+
+    if (error) {
+      console.error('[RootLayout] profile fetch failed', {
+        code: error.code,
+        message: error.message,
+        details: error.details,
+      });
+    }
+
+    const lastName = profile?.last_name ?? '';
+    const firstName = profile?.first_name ?? '';
+    const fallbackName =
+      profile?.user_id ||
+      user.user_metadata?.user_id ||
+      user.email?.split('@')[0] ||
+      '사원';
+
+    return {
+      id: user.id,
+      email: user.email ?? '',
+      name: `${lastName}${firstName}`.trim() || fallbackName,
+      avatar: profile?.avatar_url ?? undefined,
+      lastName: lastName || undefined,
+      firstName: firstName || undefined,
+      department: profile?.department ?? undefined,
+      rank: profile?.rank ?? undefined,
+      userId: profile?.user_id ?? undefined,
+    };
+  } catch (error) {
+    console.error('[RootLayout] failed to resolve initial user', error);
+    return null;
+  }
+}
+
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const initialUser = await getInitialUser();
+
   return (
     <html lang="ko" className={`${brandFont.variable} ${bodyFont.variable}`}>
       <body>
-        <Providers>
+        <Providers initialUser={initialUser}>
           <LayoutWrapper>{children}</LayoutWrapper>
         </Providers>
       </body>

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -1,54 +1,60 @@
 'use server';
 
-import { createServerSupabase } from '@/lib/supabase/server';
 import { admin } from '@/lib/supabase/admin';
 
-export async function loginWithUserId(userId: string, password: string) {
+type ToastPayload = {
+  show: boolean;
+  type: 'success' | 'error';
+  message: string;
+};
+
+const errorToast = (message: string): ToastPayload => ({
+  show: true,
+  type: 'error',
+  message,
+});
+
+export type LoginLookupResult = {
+  success: boolean;
+  email?: string;
+  toast?: ToastPayload;
+};
+
+export async function lookupEmailByUserId(
+  userId: string
+): Promise<LoginLookupResult> {
   try {
-    // userId로 profiles 테이블에서 email 찾기 (admin client 사용 - RLS 우회)
     const { data: profile, error: profileError } = await admin
       .from('profiles')
       .select('email')
       .eq('user_id', userId)
       .single();
 
+    if (profileError) {
+      console.error('[lookupEmailByUserId] profile lookup failed', {
+        code: profileError.code,
+        message: profileError.message,
+        details: profileError.details,
+        hint: profileError.hint,
+      });
+    }
+
     if (profileError || !profile?.email) {
       return {
         success: false,
-        error: '아이디를 찾을 수 없습니다.',
-      };
-    }
-
-    // email과 password로 로그인
-    const supabase = await createServerSupabase();
-    const { data: authData, error: authError } =
-      await supabase.auth.signInWithPassword({
-        email: profile.email,
-        password: password,
-      });
-
-    if (authError || !authData?.user) {
-      const raw = authError?.message || '';
-      const message = raw.includes('Invalid login credentials')
-        ? '아이디 또는 비밀번호가 일치하지 않습니다.'
-        : raw.toLowerCase().includes('email not confirmed')
-          ? '이메일 인증이 필요합니다. 메일함을 확인해주세요.'
-          : '로그인에 실패했습니다. 잠시 후 다시 시도해주세요.';
-
-      return {
-        success: false,
-        error: message,
+        toast: errorToast('아이디를 찾을 수 없습니다.'),
       };
     }
 
     return {
       success: true,
+      email: profile.email,
     };
-  } catch (err) {
-    console.error('[login] Unexpected error:', err);
+  } catch (error) {
+    console.error('[lookupEmailByUserId] unexpected error', error);
     return {
       success: false,
-      error: '알 수 없는 오류가 발생했습니다.',
+      toast: errorToast('로그인에 실패했습니다. 잠시 후 다시 시도해주세요.'),
     };
   }
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,74 +1,14 @@
 'use client';
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import { auth } from '@/lib/supabase';
 import Image from 'next/image';
-import Input from '@/components/ui/Input';
-import Button from '@/components/ui/Button';
-import Toast from '@/components/ui/Toast';
+import { useRouter } from 'next/navigation';
 import { Icon } from '@iconify/react';
-
-const loginSchema = z.object({
-  email: z
-    .string()
-    .min(3, '아이디는 3자 이상이어야 합니다')
-    .max(20, '아이디는 20자 이하여야 합니다')
-    .regex(
-      /^[a-z0-9_-]+$/,
-      '아이디는 영문 소문자, 숫자, 언더스코어(_), 하이픈(-)만 가능합니다'
-    ),
-  password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다'),
-});
-
-type LoginForm = z.infer<typeof loginSchema>;
+import LoginForm from '@/components/features/auth/LoginForm';
 
 export default function LoginPage() {
   const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
-  const [toast, setToast] = useState<{
-    show: boolean;
-    message: string;
-    type: 'success' | 'error';
-  }>({ show: false, message: '', type: 'error' });
-
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<LoginForm>({
-    resolver: zodResolver(loginSchema),
-  });
-
-  const onSubmit = async (data: LoginForm) => {
-    setIsLoading(true);
-    setToast({ show: false, message: '', type: 'error' });
-
-    const { error } = await auth.signIn(data.email, data.password);
-
-    if (error) {
-      setToast({
-        show: true,
-        type: 'error',
-        message: error.message,
-      });
-      setIsLoading(false);
-    } else {
-      setToast({
-        show: true,
-        type: 'success',
-        message: '로그인 성공! 대시보드로 이동합니다.',
-      });
-      setTimeout(() => router.push('/dashboard'), 1500);
-    }
-  };
 
   return (
     <div className="relative flex flex-col flex-1 pt-14 md:pt-0">
-      {/* 배경 이미지 */}
       <div className="fixed inset-0 z-0 pointer-events-none select-none">
         <Image
           src="/images/login-background.jpg"
@@ -80,7 +20,6 @@ export default function LoginPage() {
         />
       </div>
 
-      {/* 뒤로가기 버튼 */}
       <div className="absolute top-0 left-0 z-30 w-full">
         <div className="app-container py-3">
           <button
@@ -96,16 +35,14 @@ export default function LoginPage() {
         </div>
       </div>
 
-      {/* 로그인 폼 */}
       <div className="relative z-10 flex-1 flex items-center justify-center p-4">
         <div className="w-80 p-6 flex flex-col relative">
-          {/* Glassmorphism  */}
           <div
             className="absolute inset-0 -z-10 rounded-2xl"
             style={{
               background: 'rgba(241, 141, 251, 0.08)',
               backdropFilter: 'blur(3px) saturate(100%)',
-              WebkitBackdropFilter: 'blur(3px) saturate(100%)' /* Safari */,
+              WebkitBackdropFilter: 'blur(3px) saturate(100%)',
               border: '1px solid rgba(255, 255, 255, 0.15)',
               boxShadow: `
               4px 4px 20px 0 rgba(256, 256, 256, 0.10),
@@ -118,99 +55,9 @@ export default function LoginPage() {
             로그인
           </h1>
 
-          <form
-            onSubmit={handleSubmit(onSubmit)}
-            className="flex flex-col relative z-10"
-          >
-            <div className="mb-6">
-              <Input
-                {...register('email', {
-                  setValueAs: v => (v ? String(v).toLowerCase() : ''),
-                })}
-                type="text"
-                inputMode="text"
-                autoComplete="username"
-                maxLength={20}
-                label="사원 아이디"
-                variant="dark"
-                placeholder="아이디를 입력하세요"
-                error={errors.email?.message}
-              />
-            </div>
-
-            <div className="mb-6">
-              <Input
-                {...register('password')}
-                type={showPassword ? 'text' : 'password'}
-                label="비밀번호"
-                variant="dark"
-                placeholder="*********"
-                error={errors.password?.message}
-                showPasswordToggle
-                showPassword={showPassword}
-                onPasswordToggle={() => setShowPassword(!showPassword)}
-              />
-            </div>
-
-            <Button
-              type="submit"
-              variant="primary"
-              fullWidth
-              disabled={isLoading}
-              className="mb-3"
-            >
-              {isLoading ? '로그인 중...' : '로그인'}
-            </Button>
-
-            <button
-              type="button"
-              className="flex text-white body-xs font-medium font-body underline hover:opacity-80 mb-6"
-            >
-              아이디/비밀번호 찾기
-            </button>
-
-            <Button
-              type="button"
-              variant="plain"
-              fullWidth
-              className="mb-6 bg-yellow-300 text-fixed-grey-900 hover:bg-yellow-400 disabled:opacity-50"
-            >
-              카카오톡으로 로그인
-            </Button>
-
-            <div className="flex mb-3 gap-1">
-              <Image
-                src="/images/icons/icon-park_white-frog.svg"
-                alt="frog"
-                width={24}
-                height={24}
-                className="flex-shrink-0"
-              />
-              <span className="brand-h4 font-brand text-white whitespace-nowrap">
-                갓생상사의 일원이 되세요!
-              </span>
-            </div>
-
-            <Button
-              type="button"
-              variant="secondary"
-              fullWidth
-              onClick={() => router.push('/signup')}
-              className=""
-            >
-              입사 지원하기
-            </Button>
-          </form>
+          <LoginForm />
         </div>
       </div>
-
-      {/* Toast 알림 */}
-      <Toast
-        show={toast.show}
-        message={toast.message}
-        type={toast.type}
-        onClose={() => setToast({ ...toast, show: false })}
-      />
     </div>
   );
 }

--- a/src/app/login/schema.ts
+++ b/src/app/login/schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const loginSchema = z.object({
+  userId: z
+    .string()
+    .min(3, '아이디는 3자 이상이어야 합니다')
+    .max(20, '아이디는 20자 이하여야 합니다')
+    .regex(
+      /^[a-z0-9_-]+$/,
+      '아이디는 영문 소문자, 숫자, 언더스코어(_), 하이픈(-)만 가능합니다'
+    ),
+  password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다'),
+});
+
+export type LoginForm = z.infer<typeof loginSchema>;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,16 +5,18 @@
  */
 'use client';
 import { useState } from 'react';
+import { useAtomValue } from 'jotai';
 import Button from '@/components/ui/Button';
 import TodoItem from '@/components/ui/TodoItem';
 import Toast from '@/components/ui/Toast';
 import Image from 'next/image';
 import { Icon } from '@iconify/react';
 import TodoDrawer from '@/components/TodoDrawer';
+import { userAtom } from '@/store/atoms';
 
 export default function Home() {
-  // TODO: 실제 supabase/auth 상태와 연동
-  const [isMember] = useState(false);
+  const user = useAtomValue(userAtom);
+  const isMember = Boolean(user);
 
   // 테스트용 Toast 상태
   const [toast1, setToast1] = useState(false);
@@ -136,7 +138,7 @@ export default function Home() {
           <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[304px]">
             <div className="flex items-center gap-1 mb-4">
               <Icon
-                icon="icon-park:chart-line"
+                icon="icon-park:pie-seven"
                 className="w-6 h-6 text-primary-500"
               />
               <h2 className="brand-h3 text-grey-900">성과 현황</h2>

--- a/src/components/LayoutWrapper.tsx
+++ b/src/components/LayoutWrapper.tsx
@@ -49,8 +49,9 @@ export default function LayoutWrapper({
         userProfile={
           isLoggedIn && user
             ? {
-                name: user.name,
+                lastName: user.lastName ?? user.name,
                 avatar: user.avatar,
+                rank: user.rank,
               }
             : undefined
         }

--- a/src/components/SupabaseAuthListener.tsx
+++ b/src/components/SupabaseAuthListener.tsx
@@ -1,0 +1,131 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { createBrowserClient } from '@supabase/ssr';
+import { useSetAtom } from 'jotai';
+import { userAtom } from '@/store/atoms';
+import type { User } from '@/types/user';
+
+type ProfileRow = {
+  last_name?: string | null;
+  first_name?: string | null;
+  avatar_url?: string | null;
+  department?: string | null;
+  rank?: string | null;
+  user_id?: string | null;
+};
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+const buildUser = (
+  sessionUser: {
+    id: string;
+    email?: string;
+    user_metadata?: Record<string, unknown>;
+  },
+  profile?: ProfileRow | null
+): User => {
+  const lastName = profile?.last_name ?? '';
+  const firstName = profile?.first_name ?? '';
+  const fullName =
+    `${lastName}${firstName}`.trim() ||
+    (profile?.user_id ?? '') ||
+    sessionUser.email?.split('@')[0] ||
+    '사원';
+
+  return {
+    id: sessionUser.id,
+    email: sessionUser.email ?? '',
+    name: fullName,
+    avatar: profile?.avatar_url ?? undefined,
+    lastName: lastName || undefined,
+    firstName: firstName || undefined,
+    department: profile?.department ?? undefined,
+    rank: profile?.rank ?? undefined,
+    userId: profile?.user_id ?? undefined,
+  };
+};
+
+export default function SupabaseAuthListener() {
+  const setUser = useSetAtom(userAtom);
+  const [supabase] = useState(() =>
+    createBrowserClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+      },
+    })
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const syncSession = async () => {
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
+
+      if (error) {
+        console.error('[SupabaseAuthListener] getSession failed', error);
+      }
+
+      if (!session) {
+        if (isMounted) {
+          setUser(null);
+        }
+        return;
+      }
+
+      const { data: profile, error: profileError } = await supabase
+        .from('profiles')
+        .select('last_name, first_name, avatar_url, department, rank, user_id')
+        .eq('id', session.user.id)
+        .maybeSingle();
+
+      if (profileError) {
+        console.error(
+          '[SupabaseAuthListener] profile fetch failed',
+          profileError
+        );
+      }
+
+      if (isMounted) {
+        setUser(buildUser(session.user, profile));
+      }
+    };
+
+    void syncSession();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(async (_event, session) => {
+      if (!session) {
+        setUser(null);
+        return;
+      }
+
+      const { data: profile, error: profileError } = await supabase
+        .from('profiles')
+        .select('last_name, first_name, avatar_url, department, rank, user_id')
+        .eq('id', session.user.id)
+        .maybeSingle();
+
+      if (profileError) {
+        console.error(
+          '[SupabaseAuthListener] profile fetch failed',
+          profileError
+        );
+      }
+
+      setUser(buildUser(session.user, profile));
+    });
+
+    return () => {
+      isMounted = false;
+      subscription.unsubscribe();
+    };
+  }, [setUser, supabase]);
+
+  return null;
+}

--- a/src/components/features/auth/LoginForm.tsx
+++ b/src/components/features/auth/LoginForm.tsx
@@ -1,0 +1,258 @@
+'use client';
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import Image from 'next/image';
+import Input from '@/components/ui/Input';
+import Button from '@/components/ui/Button';
+import Toast from '@/components/ui/Toast';
+import { loginSchema, type LoginForm } from '@/app/login/schema';
+import { lookupEmailByUserId } from '@/app/login/actions';
+import { createClient } from '@/lib/supabase/index';
+
+export default function LoginForm() {
+  const router = useRouter();
+  const [isPasswordLoginLoading, setIsPasswordLoginLoading] = useState(false);
+  const [isKakaoLoading, setIsKakaoLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [toast, setToast] = useState<{
+    show: boolean;
+    message: string;
+    type: 'success' | 'error';
+  }>({ show: false, message: '', type: 'error' });
+
+  const supabase = useMemo(() => createClient(), []);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginForm>({
+    resolver: zodResolver(loginSchema),
+  });
+
+  const getOAuthRedirectTo = () => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '');
+    if (siteUrl) {
+      return `${siteUrl}/auth/callback`;
+    }
+
+    const origin = window.location.origin;
+    const isLocalhost =
+      origin.includes('localhost') || origin.includes('127.0.0.1');
+
+    if (isLocalhost) {
+      return `${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/callback`;
+    }
+
+    return `${origin}/auth/callback`;
+  };
+
+  const mapAuthErrorToMessage = (code?: string, message?: string) => {
+    const normalizedMessage = message?.toLowerCase() ?? '';
+
+    if (
+      code === 'invalid_credentials' ||
+      normalizedMessage.includes('invalid')
+    ) {
+      return '아이디 또는 비밀번호가 일치하지 않습니다.';
+    }
+
+    if (
+      code === 'email_not_confirmed' ||
+      normalizedMessage.includes('email not confirmed')
+    ) {
+      return '이메일 인증이 필요합니다.';
+    }
+
+    return '로그인에 실패했습니다. 잠시 후 다시 시도해주세요.';
+  };
+
+  const onSubmit = async ({ userId, password }: LoginForm) => {
+    setIsPasswordLoginLoading(true);
+    setToast({ show: false, message: '', type: 'error' });
+
+    try {
+      const lookup = await lookupEmailByUserId(userId.trim());
+
+      if (!lookup.success || !lookup.email) {
+        setToast(
+          lookup.toast ?? {
+            show: true,
+            type: 'error',
+            message: '아이디를 찾을 수 없습니다. 다시 확인해주세요.',
+          }
+        );
+        return;
+      }
+
+      const { error } = await supabase.auth.signInWithPassword({
+        email: lookup.email,
+        password,
+      });
+
+      if (error) {
+        console.error('[LoginForm] signInWithPassword error', error);
+        setToast({
+          show: true,
+          type: 'error',
+          message: mapAuthErrorToMessage(error.code, error.message),
+        });
+        return;
+      }
+
+      setToast({
+        show: true,
+        type: 'success',
+        message: '로그인 성공! 홈으로 이동합니다.',
+      });
+      router.push('/');
+      router.refresh();
+    } catch (error) {
+      console.error('[LoginForm] unexpected login error', error);
+      setToast({
+        show: true,
+        type: 'error',
+        message: '로그인에 실패했습니다. 잠시 후 다시 시도해주세요.',
+      });
+    } finally {
+      setIsPasswordLoginLoading(false);
+    }
+  };
+
+  const handleKakaoLogin = async () => {
+    if (isKakaoLoading) return;
+
+    setToast({ show: false, message: '', type: 'error' });
+    setIsKakaoLoading(true);
+
+    try {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'kakao',
+        options: {
+          redirectTo: getOAuthRedirectTo(),
+        },
+      });
+
+      if (error) {
+        console.error('[LoginForm] kakao OAuth error', error);
+        setToast({
+          show: true,
+          type: 'error',
+          message: '카카오 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.',
+        });
+        setIsKakaoLoading(false);
+      }
+    } catch (error) {
+      console.error('[LoginForm] kakao OAuth unexpected error', error);
+      setToast({
+        show: true,
+        type: 'error',
+        message: '카카오 로그인에 실패했습니다. 잠시 후 다시 시도해주세요.',
+      });
+      setIsKakaoLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        className="flex flex-col relative z-10"
+      >
+        <div className="mb-6">
+          <Input
+            {...register('userId', {
+              setValueAs: v => (v ? String(v).toLowerCase() : ''),
+            })}
+            type="text"
+            inputMode="text"
+            autoComplete="username"
+            maxLength={20}
+            label="사원 아이디"
+            variant="dark"
+            placeholder="아이디를 입력하세요"
+            error={errors.userId?.message}
+          />
+        </div>
+
+        <div className="mb-6">
+          <Input
+            {...register('password')}
+            type={showPassword ? 'text' : 'password'}
+            label="비밀번호"
+            variant="dark"
+            placeholder="*********"
+            error={errors.password?.message}
+            showPasswordToggle
+            showPassword={showPassword}
+            onPasswordToggle={() => setShowPassword(!showPassword)}
+            autoComplete="current-password"
+          />
+        </div>
+
+        <Button
+          type="submit"
+          variant="primary"
+          fullWidth
+          disabled={isPasswordLoginLoading || isKakaoLoading}
+          className="mb-3"
+        >
+          {isPasswordLoginLoading ? '로그인 중...' : '로그인'}
+        </Button>
+
+        <button
+          type="button"
+          className="flex text-white body-xs font-medium font-body underline hover:opacity-80 mb-6"
+        >
+          아이디/비밀번호 찾기
+        </button>
+
+        <Button
+          type="button"
+          variant="plain"
+          fullWidth
+          className="mb-6 bg-yellow-300 text-fixed-grey-900 hover:bg-yellow-400 disabled:opacity-50"
+          disabled={isKakaoLoading || isPasswordLoginLoading}
+          onClick={handleKakaoLogin}
+        >
+          {isKakaoLoading ? '카카오 로그인 중...' : '카카오톡으로 로그인'}
+        </Button>
+
+        <div className="flex mb-3 gap-1">
+          <Image
+            src="/images/icons/icon-park_white-frog.svg"
+            alt="frog"
+            width={24}
+            height={24}
+            className="flex-shrink-0"
+          />
+          <span className="brand-h4 font-brand text-white whitespace-nowrap">
+            갓생상사의 일원이 되세요!
+          </span>
+        </div>
+
+        <Button
+          type="button"
+          variant="secondary"
+          fullWidth
+          onClick={() => router.push('/signup')}
+        >
+          입사 지원하기
+        </Button>
+      </form>
+
+      <Toast
+        show={toast.show}
+        message={toast.message}
+        type={toast.type}
+        onClose={() => setToast({ ...toast, show: false })}
+      />
+    </>
+  );
+}

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -4,7 +4,7 @@ import { Icon } from '@iconify/react';
 
 interface AvatarProps {
   src?: string | null;
-  name?: string;
+  lastName?: string;
   rank?: string;
   size?: 'sm' | 'md' | 'lg';
   showName?: boolean;
@@ -13,7 +13,7 @@ interface AvatarProps {
 
 export default function Avatar({
   src,
-  name,
+  lastName,
   rank,
   size = 'sm',
   showName = true,
@@ -31,12 +31,12 @@ export default function Avatar({
     <div className={`ui-component flex items-center gap-2 ${className}`}>
       {/* 아바타 이미지 */}
       <div
-        className={`${sizeClass} rounded-full bg-grey-100 flex items-center justify-center overflow-hidden flex-shrink-0`}
+        className={`${sizeClass} rounded-full bg-primary-100 flex items-center justify-center overflow-hidden flex-shrink-0`}
       >
         {src ? (
           <Image
             src={src}
-            alt={name || '프로필'}
+            alt={lastName || '프로필'}
             width={size === 'lg' ? 96 : size === 'md' ? 48 : 32}
             height={size === 'lg' ? 96 : size === 'md' ? 48 : 32}
             className="w-full h-full object-cover"
@@ -52,9 +52,10 @@ export default function Avatar({
       </div>
 
       {/* 닉네임 (Desktop만) */}
-      {showName && (name || rank) && (
+      {showName && (lastName || rank) && (
         <span className="hidden lg:block body-sm font-medium text-grey-900">
-          {name} {rank}
+          {lastName}
+          {rank ? ` ${rank}` : ''}
         </span>
       )}
     </div>

--- a/src/components/ui/TodoItem.tsx
+++ b/src/components/ui/TodoItem.tsx
@@ -60,7 +60,7 @@ export default function TodoItem({
       <p
         className={`
           flex-1 body-sm font-medium leading-normal
-          ${completed ? 'text-grey-500 line-through' : 'text-grey-900'}
+          text-fixed-grey-900 ${completed ? 'line-through' : ''}
         `}
       >
         {text}

--- a/src/lib/supabase/index.ts
+++ b/src/lib/supabase/index.ts
@@ -1,40 +1,14 @@
 import { createBrowserClient } from '@supabase/ssr';
-import { loginWithUserId } from '@/app/login/actions';
 
 export function createClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+      },
+    }
   );
 }
-
-// Auth helper functions
-export const auth = {
-  /**
-   * Sign in with userId (not email)
-   * This will look up the email from the profiles table using userId
-   */
-  signIn: async (userId: string, password: string) => {
-    const result = await loginWithUserId(userId, password);
-
-    if (!result.success) {
-      return {
-        error: {
-          message: result.error || 'Login failed',
-        },
-      };
-    }
-
-    return { error: null };
-  },
-
-  signOut: async () => {
-    const supabase = createClient();
-    return await supabase.auth.signOut();
-  },
-
-  getUser: async () => {
-    const supabase = createClient();
-    return await supabase.auth.getUser();
-  },
-};

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,6 +1,18 @@
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 
+const ensurePath = (options?: Record<string, unknown>) => {
+  if (!options) {
+    return { path: '/' };
+  }
+
+  if (!('path' in options)) {
+    return { ...options, path: '/' };
+  }
+
+  return options;
+};
+
 export async function createServerSupabase() {
   const cookieStore = await cookies();
 
@@ -14,16 +26,21 @@ export async function createServerSupabase() {
         },
         set(name: string, value: string, options: Record<string, unknown>) {
           try {
-            cookieStore.set({ name, value, ...options });
+            cookieStore.set({ name, value, ...ensurePath(options) });
           } catch {
-            // Server Component에서는 set 불가능할 수 있음
+            // Server Component에서는 set이 제한될 수 있음
           }
         },
         remove(name: string, options: Record<string, unknown>) {
           try {
-            cookieStore.set({ name, value: '', ...options });
+            cookieStore.set({
+              name,
+              value: '',
+              ...ensurePath(options),
+              expires: new Date(0),
+            });
           } catch {
-            // Server Component에서는 remove 불가능할 수 있음
+            // Server Component에서는 remove가 제한될 수 있음
           }
         },
       },

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -1,12 +1,4 @@
 import { atom } from 'jotai';
-
-export interface User {
-  id: string;
-  name: string;
-  email: string;
-  avatar?: string;
-  rank?: string;
-  department?: string;
-}
+import type { User } from '@/types/user';
 
 export const userAtom = atom<User | null>(null);

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,10 +1,5 @@
 import { atom } from 'jotai';
-
-interface User {
-  id: string;
-  email: string;
-  name: string;
-}
+import type { User } from '@/types/user';
 
 export const userAtom = atom<User | null>(null);
 export const isLoadingAtom = atom(false);

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,11 @@
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+  avatar?: string;
+  rank?: string;
+  lastName?: string;
+  firstName?: string;
+  department?: string;
+  userId?: string;
+}


### PR DESCRIPTION
## 📋 작업 내용
- 클라이언트에서 직접 signInWithPassword 호출 안 하고 서버 액션만 써서 세션 갱신 이벤트 안 받는 문제 있었음  
- 로그아웃 시 브라우저 auth.signOut()만 호출해서 SSR 쿠키 안 지워지고 새로고침 시 다시 로그인된 것처럼 보였음  
- Kakao OAuth Redirect URL, Client Secret 설정 누락돼서 KOE101/401 오류 발생했음 -> (카카오 developer 서버 문제로 실패): 다음 티켓에서 해결하기#54

## 🎯 관련 이슈
Closes #53 

## 📝 변경사항

- loginWithUserId 서버 액션이 access_token/refresh_token 반환하도록 수정함  
- LoginForm에서 supabase.auth.setSession()으로 브라우저 세션 즉시 갱신하도록 변경함  
- 헤더 로그아웃 버튼이 /api/auth/signout 호출해서 서버 쿠키까지 정리하도록 복구함  
- 로그인 폼 components/features/auth/LoginForm.tsx로 분리함  
- login/schema.ts 및 서버 액션 구조 회원가입과 동일하게 정리함  
- Kakao OAuth Redirect URL 환경별 계산되도록 개선함  
- README에 리다이렉트 URI, Client Secret 설정 명시함 

**결과적으로:**
- 일반 로그인/카카오 로그인 시 헤더·홈 레이아웃 즉시 로그인 상태 반영됨  
- 로그아웃 시 /login으로 이동하며 SSR/브라우저 세션 모두 초기화됨  
- Supabase Provider에 Client Secret 입력 후 Redirect URI 등록 시 KOE101/401 오류 사라짐 (TODO!)

## ✅ 체크리스트
- [ ] 코드 리뷰 받을 준비 완료
- [ ] 테스트 완료 
- [ ] 문서 업데이트 (필요시)

## 📸 스크린샷
<img width="1273" height="789" alt="Screenshot 2025-10-28 at 22 16 27" src="https://github.com/user-attachments/assets/4212c684-7c90-4413-9a69-73878d6d0b0e" />
