### PR TITLE
[Feat] implement attendance section with Supabase integration

### DIFF
--- a/src/app/_actions/attendance.ts
+++ b/src/app/_actions/attendance.ts
@@ -1,0 +1,135 @@
+'use server';
+
+import { createServerSupabase } from '@/lib/supabase/server';
+
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+export type AttendanceStatus = 'none' | 'in' | 'early' | 'out';
+
+export type AttendanceLog = {
+  id: string;
+  user_id: string;
+  work_date: string;
+  clock_in_at: string | null;
+  early_leave_at: string | null;
+  clock_out_at: string | null;
+  work_minutes: number;
+  status: AttendanceStatus;
+  created_at: string;
+  updated_at: string;
+};
+
+type AttendanceResponse =
+  | { ok: true; data: AttendanceLog }
+  | { ok: true; data: null }
+  | { ok: false; error: string };
+
+type MutationResponse =
+  | { ok: true; data: AttendanceLog | null }
+  | { ok: false; error: string };
+
+type AttendanceRateResponse =
+  | { ok: true; rate: number }
+  | { ok: false; error: string };
+
+function todayKstDate() {
+  const now = new Date();
+  const kst = new Date(now.getTime() + KST_OFFSET_MS);
+  return kst.toISOString().slice(0, 10);
+}
+
+async function getUserSupabaseClient() {
+  const supabase = await createServerSupabase();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return { ok: false as const, error: 'UNAUTHENTICATED' };
+  }
+
+  return { ok: true as const, supabase, user };
+}
+
+export async function getTodayStatus(): Promise<AttendanceResponse> {
+  const client = await getUserSupabaseClient();
+  if (!client.ok) return client;
+
+  const workDate = todayKstDate();
+
+  const { data, error } = await client.supabase
+    .from('attendance_logs')
+    .select('*')
+    .eq('user_id', client.user.id)
+    .eq('work_date', workDate)
+    .maybeSingle();
+
+  if (error) return { ok: false, error: error.message };
+
+  return { ok: true, data: (data as AttendanceLog | null) ?? null };
+}
+
+export async function clockIn(): Promise<MutationResponse> {
+  const client = await getUserSupabaseClient();
+  if (!client.ok) return client;
+
+  const workDate = todayKstDate();
+
+  const { data, error } = await client.supabase.rpc('fn_clock_in', {
+    p_user_id: client.user.id,
+    p_work_date: workDate,
+  });
+
+  return error
+    ? { ok: false, error: error.message }
+    : { ok: true, data: (data as AttendanceLog | null) ?? null };
+}
+
+export async function earlyLeave(): Promise<MutationResponse> {
+  const client = await getUserSupabaseClient();
+  if (!client.ok) return client;
+
+  const workDate = todayKstDate();
+
+  const { data, error } = await client.supabase.rpc('fn_early_leave', {
+    p_user_id: client.user.id,
+    p_work_date: workDate,
+  });
+
+  return error
+    ? { ok: false, error: error.message }
+    : { ok: true, data: (data as AttendanceLog | null) ?? null };
+}
+
+export async function clockOut(): Promise<MutationResponse> {
+  const client = await getUserSupabaseClient();
+  if (!client.ok) return client;
+
+  const workDate = todayKstDate();
+
+  const { data, error } = await client.supabase.rpc('fn_clock_out', {
+    p_user_id: client.user.id,
+    p_work_date: workDate,
+  });
+
+  return error
+    ? { ok: false, error: error.message }
+    : { ok: true, data: (data as AttendanceLog | null) ?? null };
+}
+
+export async function getAttendanceRate(): Promise<AttendanceRateResponse> {
+  const client = await getUserSupabaseClient();
+  if (!client.ok) return client;
+
+  const { data, error } = await client.supabase
+    .from('v_attendance_summary')
+    .select('attendance_rate')
+    .eq('user_id', client.user.id)
+    .maybeSingle();
+
+  if (error) return { ok: false, error: error.message };
+
+  const rateRow = data as { attendance_rate: number | null } | null;
+  return { ok: true, rate: rateRow?.attendance_rate ?? 0 };
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,14 +13,13 @@ import Image from 'next/image';
 import { Icon } from '@iconify/react';
 import TodoDrawer from '@/components/TodoDrawer';
 import { userAtom } from '@/store/atoms';
+import AttendanceCard from '@/components/home/AttendanceCard';
 
 export default function Home() {
   const user = useAtomValue(userAtom);
   const isMember = Boolean(user);
 
   // 테스트용 Toast 상태
-  const [toast1, setToast1] = useState(false);
-  const [toast2, setToast2] = useState(false);
   const [toast3, setToast3] = useState(false);
 
   // 테스트용 Todo 상태
@@ -59,18 +58,6 @@ export default function Home() {
     <>
       {/* Toasts */}
       <Toast
-        show={toast1}
-        message="출근 완료, 활기찬 갓생 보내세요!"
-        type="success"
-        onClose={() => setToast1(false)}
-      />
-      <Toast
-        show={toast2}
-        message="퇴근 완료! 수고하셨습니다 🎉"
-        type="success"
-        onClose={() => setToast2(false)}
-      />
-      <Toast
         show={toast3}
         message="내 글에 새 댓글이 달렸어요"
         type="info"
@@ -88,27 +75,7 @@ export default function Home() {
         /* ===================== 회원 레이아웃 ===================== */
         <>
           {/* 근태관리 */}
-          <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[207px]">
-            <div className="flex items-center gap-1 mb-4">
-              <Icon
-                icon="icon-park:briefcase"
-                className="w-6 h-6 text-primary-500"
-              />
-              <h2 className="brand-h3 text-grey-900">근태관리</h2>
-            </div>
-            <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <Button
-                variant="primary"
-                fullWidth
-                onClick={() => setToast1(true)}
-              >
-                출근하기
-              </Button>
-              <Button variant="text" fullWidth onClick={() => setToast2(true)}>
-                퇴근하기
-              </Button>
-            </div>
-          </section>
+          <AttendanceCard />
 
           {/* 사원정보 */}
           <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[207px]">

--- a/src/components/home/AttendanceCard.tsx
+++ b/src/components/home/AttendanceCard.tsx
@@ -1,0 +1,470 @@
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from 'react';
+import { Icon } from '@iconify/react';
+import Button from '@/components/ui/Button';
+import Toast from '@/components/ui/Toast';
+import {
+  AttendanceLog,
+  AttendanceStatus,
+  clockIn,
+  clockOut,
+  earlyLeave,
+  getAttendanceRate,
+  getTodayStatus,
+} from '@/app/_actions/attendance';
+
+type AttendanceState = {
+  status: AttendanceStatus;
+  clockInAt: string | null;
+  earlyLeaveAt: string | null;
+  clockOutAt: string | null;
+  workMinutes: number;
+};
+
+type ToastState = {
+  message: string;
+  type: 'success' | 'error';
+} | null;
+
+const initialAttendanceState: AttendanceState = {
+  status: 'none',
+  clockInAt: null,
+  earlyLeaveAt: null,
+  clockOutAt: null,
+  workMinutes: 0,
+};
+
+const MS_IN_MINUTE = 60_000;
+
+function deriveAttendanceState(log: AttendanceLog | null): AttendanceState {
+  if (!log) return initialAttendanceState;
+
+  return {
+    status: (log.status as AttendanceStatus) ?? 'none',
+    clockInAt: log.clock_in_at,
+    earlyLeaveAt: log.early_leave_at,
+    clockOutAt: log.clock_out_at,
+    workMinutes: log.work_minutes ?? 0,
+  };
+}
+
+function diffMinutes(from?: string | null, to?: string | null) {
+  if (!from || !to) return 0;
+  const start = new Date(from).getTime();
+  const end = new Date(to).getTime();
+  if (Number.isNaN(start) || Number.isNaN(end) || end <= start) return 0;
+  return Math.round((end - start) / MS_IN_MINUTE);
+}
+
+function formatMinutes(totalMinutes: number) {
+  if (totalMinutes <= 0) return '0분';
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours && minutes) return `${hours}시간 ${minutes}분`;
+  if (hours) return `${hours}시간`;
+  return `${minutes}분`;
+}
+
+export default function AttendanceCard() {
+  const [attendance, setAttendance] = useState<AttendanceState>(
+    initialAttendanceState
+  );
+  const [attendanceRate, setAttendanceRate] = useState<number>(0);
+  const [liveMinutes, setLiveMinutes] = useState<number>(0);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [toast, setToast] = useState<ToastState>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const showToast = useCallback(
+    (message: string, type: 'success' | 'error') => {
+      setToast({ message, type });
+    },
+    []
+  );
+
+  const refreshAttendanceRate = useCallback(async () => {
+    const rateRes = await getAttendanceRate();
+    if (rateRes.ok) {
+      setAttendanceRate(rateRes.rate);
+    } else if (rateRes.error !== 'UNAUTHENTICATED') {
+      showToast('출근율 정보를 갱신하지 못했어요.', 'error');
+    }
+  }, [showToast]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function bootstrap() {
+      try {
+        setIsLoading(true);
+        const [statusRes, rateRes] = await Promise.all([
+          getTodayStatus(),
+          getAttendanceRate(),
+        ]);
+
+        if (!mounted) return;
+
+        if (statusRes.ok) {
+          setAttendance(deriveAttendanceState(statusRes.data ?? null));
+        } else if (statusRes.error !== 'UNAUTHENTICATED') {
+          showToast('근태 정보를 불러오지 못했어요.', 'error');
+        }
+
+        if (rateRes.ok) {
+          setAttendanceRate(rateRes.rate);
+        } else if (rateRes.error !== 'UNAUTHENTICATED') {
+          showToast('출근율 정보를 불러오지 못했어요.', 'error');
+        }
+      } catch {
+        if (mounted) {
+          showToast('근태 데이터를 불러오는 중 문제가 발생했어요.', 'error');
+        }
+      } finally {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    bootstrap();
+
+    return () => {
+      mounted = false;
+    };
+  }, [showToast]);
+
+  useEffect(() => {
+    if (attendance.status !== 'in' || !attendance.clockInAt) {
+      setLiveMinutes(0);
+      return;
+    }
+
+    const updateMinutes = () => {
+      const diff = diffMinutes(attendance.clockInAt, new Date().toISOString());
+      setLiveMinutes(diff);
+    };
+
+    updateMinutes();
+
+    const timer = setInterval(updateMinutes, MS_IN_MINUTE);
+    return () => clearInterval(timer);
+  }, [attendance.status, attendance.clockInAt]);
+
+  const todayMinutes = useMemo(() => {
+    switch (attendance.status) {
+      case 'in':
+        return liveMinutes;
+      case 'early':
+        return (
+          diffMinutes(attendance.clockInAt, attendance.earlyLeaveAt) ||
+          attendance.workMinutes
+        );
+      case 'out':
+        return attendance.workMinutes;
+      default:
+        return 0;
+    }
+  }, [attendance, liveMinutes]);
+
+  const todayLabel = useMemo(() => {
+    switch (attendance.status) {
+      case 'in':
+        return `${formatMinutes(todayMinutes)}째 근무 중`;
+      case 'early':
+        return `조퇴 처리 완료 · ${formatMinutes(todayMinutes)} 근무`;
+      case 'out':
+        return `오늘 근무 완료 · ${formatMinutes(todayMinutes)} 근무`;
+      default:
+        return '시간 째 근무 중';
+    }
+  }, [attendance.status, todayMinutes]);
+
+  const todayPrimaryNumber = useMemo(() => {
+    if (isLoading) return 0;
+    if (attendance.status === 'in') {
+      return Math.floor(todayMinutes / 60);
+    }
+    if (attendance.status === 'early' || attendance.status === 'out') {
+      return Math.floor(todayMinutes / 60);
+    }
+    return 0;
+  }, [attendance.status, isLoading, todayMinutes]);
+
+  const todaySecondaryLabel = useMemo(() => {
+    if (isLoading) return '시간째 근무 중';
+    switch (attendance.status) {
+      case 'in':
+        return '시간째 근무 중';
+      case 'early':
+      case 'out':
+        return `${formatMinutes(todayMinutes)} 근무`;
+      default:
+        return '시간째 근무 중';
+    }
+  }, [attendance.status, isLoading, todayMinutes]);
+
+  const handleClockIn = useCallback(() => {
+    if (isPending) return;
+
+    const optimisticState: AttendanceState = {
+      status: 'in',
+      clockInAt: new Date().toISOString(),
+      earlyLeaveAt: null,
+      clockOutAt: null,
+      workMinutes: 0,
+    };
+
+    const previous = attendance;
+    setAttendance(optimisticState);
+
+    startTransition(async () => {
+      const result = await clockIn();
+      if (!result.ok) {
+        setAttendance(previous);
+        showToast(
+          result.error === 'UNAUTHENTICATED'
+            ? '로그인이 필요해요.'
+            : '출근 처리에 실패했어요.',
+          'error'
+        );
+        return;
+      }
+
+      const log = result.data;
+      if (!log) {
+        setAttendance(previous);
+        showToast('출근 정보가 확인되지 않아요.', 'error');
+        return;
+      }
+
+      setAttendance(deriveAttendanceState(log));
+      await refreshAttendanceRate();
+      showToast('출근 완료! 활기찬 하루 되세요.', 'success');
+    });
+  }, [
+    attendance,
+    isPending,
+    refreshAttendanceRate,
+    showToast,
+    startTransition,
+  ]);
+
+  const handleEarlyLeave = useCallback(() => {
+    if (isPending || attendance.status !== 'in') return;
+
+    const optimisticState: AttendanceState = {
+      ...attendance,
+      status: 'early',
+      earlyLeaveAt: new Date().toISOString(),
+    };
+    const previous = attendance;
+    setAttendance(optimisticState);
+
+    startTransition(async () => {
+      const result = await earlyLeave();
+      if (!result.ok) {
+        setAttendance(previous);
+        const message =
+          result.error === 'UNAUTHENTICATED'
+            ? '로그인이 필요해요.'
+            : result.error.includes('No clock-in record')
+              ? '오늘 출근 기록이 없습니다.'
+              : '조퇴 처리에 실패했어요.';
+        showToast(message, 'error');
+        return;
+      }
+
+      const log = result.data;
+      if (!log) {
+        setAttendance(previous);
+        showToast('조퇴 정보가 확인되지 않아요.', 'error');
+        return;
+      }
+
+      setAttendance(deriveAttendanceState(log));
+      showToast('조퇴가 기록되었어요.', 'success');
+    });
+  }, [attendance, isPending, showToast, startTransition]);
+
+  const handleClockOut = useCallback(() => {
+    if (isPending || attendance.status === 'none') return;
+
+    const optimisticState: AttendanceState = {
+      ...attendance,
+      status: 'out',
+      clockOutAt: new Date().toISOString(),
+      workMinutes:
+        attendance.status === 'early'
+          ? diffMinutes(attendance.clockInAt, attendance.earlyLeaveAt)
+          : diffMinutes(attendance.clockInAt, new Date().toISOString()),
+    };
+
+    const previous = attendance;
+    setAttendance(optimisticState);
+
+    startTransition(async () => {
+      const result = await clockOut();
+      if (!result.ok) {
+        setAttendance(previous);
+        const message =
+          result.error === 'UNAUTHENTICATED'
+            ? '로그인이 필요해요.'
+            : result.error.includes('No clock-in record')
+              ? '오늘 출근 기록이 없습니다.'
+              : '퇴근 처리에 실패했어요.';
+        showToast(message, 'error');
+        return;
+      }
+
+      const log = result.data;
+      if (!log) {
+        setAttendance(previous);
+        showToast('퇴근 정보가 확인되지 않아요.', 'error');
+        return;
+      }
+
+      setAttendance(deriveAttendanceState(log));
+      await refreshAttendanceRate();
+      showToast('퇴근 완료! 수고하셨습니다.', 'success');
+    });
+  }, [
+    attendance,
+    isPending,
+    refreshAttendanceRate,
+    showToast,
+    startTransition,
+  ]);
+
+  const statusBadge = useMemo(() => {
+    switch (attendance.status) {
+      case 'in':
+        return { label: '근무 중', tone: 'text-primary-500' };
+      case 'early':
+        return { label: '조퇴 처리', tone: 'text-warning-500' };
+      case 'out':
+        return { label: '근무 완료', tone: 'text-success-500' };
+      default:
+        return { label: '대기 중', tone: 'text-grey-500' };
+    }
+  }, [attendance.status]);
+
+  const primaryButton = useMemo(() => {
+    switch (attendance.status) {
+      case 'in':
+      case 'early':
+        return {
+          label: '조퇴하기',
+          variant: 'secondary' as const,
+          onClick: handleEarlyLeave,
+          disabled: attendance.status === 'early' || isPending,
+        };
+      case 'out':
+        return {
+          label: '출근하기',
+          variant: 'primary' as const,
+          onClick: handleClockIn,
+          disabled: true,
+        };
+      default:
+        return {
+          label: '출근하기',
+          variant: 'primary' as const,
+          onClick: handleClockIn,
+          disabled: isPending,
+        };
+    }
+  }, [attendance.status, handleClockIn, handleEarlyLeave, isPending]);
+
+  const secondaryButton = useMemo(() => {
+    switch (attendance.status) {
+      case 'none':
+        return {
+          label: '퇴근하기',
+          variant: 'text' as const,
+          onClick: handleClockOut,
+          disabled: true,
+        };
+      case 'out':
+        return {
+          label: '퇴근하기',
+          variant: 'text' as const,
+          onClick: handleClockOut,
+          disabled: true,
+        };
+      default:
+        return {
+          label: '퇴근하기',
+          variant: 'text' as const,
+          onClick: handleClockOut,
+          disabled: isPending,
+        };
+    }
+  }, [attendance.status, handleClockOut, isPending]);
+
+  return (
+    <>
+      <section className="bg-grey-100 rounded-[5px] p-6">
+        {/* Header: Icon + Title (DNF Bit style applied via brand classes) */}
+        <div className="flex items-end gap-1">
+          <Icon icon="icon-park:briefcase" className="w-6 h-6 text-grey-900" />
+          <h2 className="brand-h3 text-grey-900">근태관리</h2>
+        </div>
+
+        {/* Today / Total row (Figma compact style) */}
+        <div className="mt-4 grid grid-cols-2 gap-x-0 gap-y-4 items-start">
+          {/* Today */}
+          <div className="flex flex-col gap-1 items-start text-left min-w-0">
+            <div className="inline-flex items-center gap-2.5">
+              <span className="text-grey-300 body-sm font-semibold">Today</span>
+            </div>
+            <div className="inline-flex items-end gap-1">
+              <span className="brand-h1 text-primary-500 tabular-nums">
+                {todayPrimaryNumber}
+              </span>
+              <span className="body-xs text-grey-500">
+                {todaySecondaryLabel}
+              </span>
+            </div>
+          </div>
+
+          {/* Total */}
+          <div className="flex flex-col gap-1 items-start text-left min-w-0">
+            <div className="inline-flex items-center gap-2.5">
+              <span className="text-grey-300 body-sm font-semibold">Total</span>
+            </div>
+            <div className="inline-flex items-baseline gap-1">
+              <span className="brand-h1 text-primary-500 tabular-nums">
+                {isLoading ? 0 : Number(attendanceRate.toFixed(0))}
+              </span>
+              <span className="body-xs text-grey-500">% 출근율</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Buttons - simpler static layout */}
+        <div className="mt-3 grid grid-cols-2 gap-3">
+          <Button variant="primary" fullWidth onClick={handleClockIn}>
+            출근하기
+          </Button>
+          <Button variant="text" fullWidth onClick={handleClockOut}>
+            퇴근하기
+          </Button>
+        </div>
+      </section>
+
+      <Toast
+        show={!!toast}
+        message={toast?.message ?? ''}
+        type={toast?.type ?? 'success'}
+        onClose={() => setToast(null)}
+      />
+    </>
+  );
+}

--- a/supabase-attendance-setup.sql
+++ b/supabase-attendance-setup.sql
@@ -1,0 +1,277 @@
+-- ============================================================================
+-- 갓생상사 근태관리 시스템 설정 스크립트
+-- ============================================================================
+-- 이 스크립트는 다음을 생성합니다:
+-- 1. attendance_logs 테이블 (출퇴근 로그)
+-- 2. v_attendance_summary 뷰 (출근율 계산)
+-- 3. fn_clock_in, fn_early_leave, fn_clock_out RPC 함수들
+-- 4. RLS (Row Level Security) 정책
+-- ============================================================================
+
+-- ============================================================================
+-- 1. attendance_logs 테이블 생성
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.attendance_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  work_date DATE NOT NULL,
+  clock_in_at TIMESTAMPTZ,
+  early_leave_at TIMESTAMPTZ,
+  clock_out_at TIMESTAMPTZ,
+  work_minutes INTEGER DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'none' CHECK (status IN ('none', 'in', 'early', 'out')),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+  -- 한 사용자는 하루에 하나의 근태 기록만 가질 수 있음
+  UNIQUE(user_id, work_date)
+);
+
+-- 인덱스 생성 (성능 최적화)
+CREATE INDEX IF NOT EXISTS idx_attendance_logs_user_id ON public.attendance_logs(user_id);
+CREATE INDEX IF NOT EXISTS idx_attendance_logs_work_date ON public.attendance_logs(work_date);
+CREATE INDEX IF NOT EXISTS idx_attendance_logs_user_date ON public.attendance_logs(user_id, work_date);
+
+-- updated_at 자동 업데이트 트리거
+CREATE OR REPLACE FUNCTION public.update_attendance_logs_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_update_attendance_logs_updated_at ON public.attendance_logs;
+CREATE TRIGGER trigger_update_attendance_logs_updated_at
+  BEFORE UPDATE ON public.attendance_logs
+  FOR EACH ROW
+  EXECUTE FUNCTION public.update_attendance_logs_updated_at();
+
+-- ============================================================================
+-- 2. RLS (Row Level Security) 정책 설정
+-- ============================================================================
+ALTER TABLE public.attendance_logs ENABLE ROW LEVEL SECURITY;
+
+-- 기존 정책 삭제 (재실행 시 충돌 방지)
+DROP POLICY IF EXISTS "Users can view own attendance logs" ON public.attendance_logs;
+DROP POLICY IF EXISTS "Users can insert own attendance logs" ON public.attendance_logs;
+DROP POLICY IF EXISTS "Users can update own attendance logs" ON public.attendance_logs;
+
+-- 사용자는 자신의 근태 기록만 조회 가능
+CREATE POLICY "Users can view own attendance logs"
+  ON public.attendance_logs
+  FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- 사용자는 자신의 근태 기록만 생성 가능
+CREATE POLICY "Users can insert own attendance logs"
+  ON public.attendance_logs
+  FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- 사용자는 자신의 근태 기록만 업데이트 가능
+CREATE POLICY "Users can update own attendance logs"
+  ON public.attendance_logs
+  FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================================
+-- 3. v_attendance_summary 뷰 생성 (출근율 계산)
+-- ============================================================================
+-- 기존 뷰 삭제 (재실행 시 충돌 방지)
+DROP VIEW IF EXISTS public.v_attendance_summary;
+
+CREATE VIEW public.v_attendance_summary AS
+SELECT
+  user_id,
+  COUNT(*) AS total_days,
+  COUNT(CASE WHEN status != 'none' THEN 1 END) AS attended_days,
+  CASE
+    WHEN COUNT(*) > 0 THEN
+      ROUND((COUNT(CASE WHEN status != 'none' THEN 1 END)::NUMERIC / COUNT(*)::NUMERIC) * 100, 2)
+    ELSE 0
+  END AS attendance_rate
+FROM public.attendance_logs
+GROUP BY user_id;
+
+-- 뷰에 대한 RLS 정책
+ALTER VIEW public.v_attendance_summary SET (security_invoker = on);
+
+-- ============================================================================
+-- 4. fn_clock_in 함수 생성 (출근 처리)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.fn_clock_in(
+  p_user_id UUID,
+  p_work_date DATE
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_existing_log public.attendance_logs;
+  v_result public.attendance_logs;
+BEGIN
+  -- 권한 확인: 본인만 출근 처리 가능
+  IF auth.uid() != p_user_id THEN
+    RAISE EXCEPTION 'Unauthorized: You can only clock in for yourself';
+  END IF;
+
+  -- 기존 기록 확인
+  SELECT * INTO v_existing_log
+  FROM public.attendance_logs
+  WHERE user_id = p_user_id AND work_date = p_work_date;
+
+  -- 이미 출근 기록이 있으면 에러
+  IF v_existing_log.id IS NOT NULL AND v_existing_log.clock_in_at IS NOT NULL THEN
+    RAISE EXCEPTION 'Already clocked in today';
+  END IF;
+
+  -- 새 출근 기록 생성 또는 업데이트
+  INSERT INTO public.attendance_logs (user_id, work_date, clock_in_at, status)
+  VALUES (p_user_id, p_work_date, NOW(), 'in')
+  ON CONFLICT (user_id, work_date)
+  DO UPDATE SET
+    clock_in_at = NOW(),
+    status = 'in',
+    updated_at = NOW()
+  RETURNING * INTO v_result;
+
+  -- JSON 형식으로 반환
+  RETURN row_to_json(v_result);
+END;
+$$;
+
+-- ============================================================================
+-- 5. fn_early_leave 함수 생성 (조퇴 처리)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.fn_early_leave(
+  p_user_id UUID,
+  p_work_date DATE
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_existing_log public.attendance_logs;
+  v_result public.attendance_logs;
+  v_work_minutes INTEGER;
+BEGIN
+  -- 권한 확인: 본인만 조퇴 처리 가능
+  IF auth.uid() != p_user_id THEN
+    RAISE EXCEPTION 'Unauthorized: You can only process early leave for yourself';
+  END IF;
+
+  -- 기존 기록 확인
+  SELECT * INTO v_existing_log
+  FROM public.attendance_logs
+  WHERE user_id = p_user_id AND work_date = p_work_date;
+
+  -- 출근 기록이 없으면 에러
+  IF v_existing_log.id IS NULL OR v_existing_log.clock_in_at IS NULL THEN
+    RAISE EXCEPTION 'No clock-in record found for today';
+  END IF;
+
+  -- 이미 조퇴 또는 퇴근 처리된 경우 에러
+  IF v_existing_log.status IN ('early', 'out') THEN
+    RAISE EXCEPTION 'Already processed early leave or clock out';
+  END IF;
+
+  -- 근무 시간 계산 (분 단위)
+  v_work_minutes := EXTRACT(EPOCH FROM (NOW() - v_existing_log.clock_in_at)) / 60;
+
+  -- 조퇴 처리
+  UPDATE public.attendance_logs
+  SET
+    early_leave_at = NOW(),
+    work_minutes = v_work_minutes,
+    status = 'early',
+    updated_at = NOW()
+  WHERE id = v_existing_log.id
+  RETURNING * INTO v_result;
+
+  -- JSON 형식으로 반환
+  RETURN row_to_json(v_result);
+END;
+$$;
+
+-- ============================================================================
+-- 6. fn_clock_out 함수 생성 (퇴근 처리)
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.fn_clock_out(
+  p_user_id UUID,
+  p_work_date DATE
+)
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_existing_log public.attendance_logs;
+  v_result public.attendance_logs;
+  v_work_minutes INTEGER;
+BEGIN
+  -- 권한 확인: 본인만 퇴근 처리 가능
+  IF auth.uid() != p_user_id THEN
+    RAISE EXCEPTION 'Unauthorized: You can only clock out for yourself';
+  END IF;
+
+  -- 기존 기록 확인
+  SELECT * INTO v_existing_log
+  FROM public.attendance_logs
+  WHERE user_id = p_user_id AND work_date = p_work_date;
+
+  -- 출근 기록이 없으면 에러
+  IF v_existing_log.id IS NULL OR v_existing_log.clock_in_at IS NULL THEN
+    RAISE EXCEPTION 'No clock-in record found for today';
+  END IF;
+
+  -- 이미 퇴근 처리된 경우 에러
+  IF v_existing_log.status = 'out' THEN
+    RAISE EXCEPTION 'Already clocked out';
+  END IF;
+
+  -- 근무 시간 계산 (분 단위)
+  -- 조퇴한 경우 조퇴 시간부터 퇴근 시간까지는 계산하지 않음
+  IF v_existing_log.status = 'early' AND v_existing_log.early_leave_at IS NOT NULL THEN
+    v_work_minutes := EXTRACT(EPOCH FROM (v_existing_log.early_leave_at - v_existing_log.clock_in_at)) / 60;
+  ELSE
+    v_work_minutes := EXTRACT(EPOCH FROM (NOW() - v_existing_log.clock_in_at)) / 60;
+  END IF;
+
+  -- 퇴근 처리
+  UPDATE public.attendance_logs
+  SET
+    clock_out_at = NOW(),
+    work_minutes = v_work_minutes,
+    status = 'out',
+    updated_at = NOW()
+  WHERE id = v_existing_log.id
+  RETURNING * INTO v_result;
+
+  -- JSON 형식으로 반환
+  RETURN row_to_json(v_result);
+END;
+$$;
+
+-- ============================================================================
+-- 7. RPC 함수에 대한 권한 부여
+-- ============================================================================
+-- 인증된 사용자만 RPC 함수 실행 가능
+GRANT EXECUTE ON FUNCTION public.fn_clock_in TO authenticated;
+GRANT EXECUTE ON FUNCTION public.fn_early_leave TO authenticated;
+GRANT EXECUTE ON FUNCTION public.fn_clock_out TO authenticated;
+
+-- ============================================================================
+-- 완료!
+-- ============================================================================
+-- 이제 다음 단계를 진행하세요:
+-- 1. Supabase SQL Editor에서 이 스크립트를 복사하여 실행
+-- 2. 실행 후 에러가 없는지 확인
+-- 3. 애플리케이션에서 출근/퇴근 기능 테스트
+-- ============================================================================


### PR DESCRIPTION
## 📋 작업 내용
- Supabase 스키마 스크립트 작성: supabase-attendance-setup.sql에 근태 테이블·뷰·RPC·RLS 일괄 생성 로직 추가
- 서버 액션 구현: src/app/_actions/attendance.ts에서 출근/조퇴/퇴근 및 출근율 조회 API 래핑
- 홈 카드 교체: src/components/home/AttendanceCard.tsx로 상태 머신·토스트·2열 레이아웃 구현 후 src/app/page.tsx에 연결
- 타입/레이아웃 보완: 모든 분기에서 타이머 UI 통일, 모바일 포함 2열 유지, Total 영역 중앙 정렬 조정

## 🎯 관련 이슈
Closes #37 

## 📝 변경사항
- SQL: attendance 로그 테이블, v_attendance_summary 뷰, fn_clock_in/early_leave/clock_out RPC, RLS 정책 신규 추가
- Server Actions: KST 기준 날짜 계산, 사용자 인증 검사, Supabase RPC 호출 및 응답 타입 정의
- UI: 근태 카드 신규 컴포넌트 도입, 낙관적 업데이트/토스트 처리, Today·Total·버튼 2컬럼 레이아웃 적용
- 기타: 기존 테스트 토스트 제거, 카드 도입 후 홈 레이아웃 정리

## ✅ 체크리스트
- [ ] 코드 리뷰 받을 준비 완료
- [ ] 테스트 완료 
- [ ] 문서 업데이트 (필요시)

## 📸 스크린샷
<img width="1219" height="967" alt="Screenshot 2025-10-30 at 23 00 10" src="https://github.com/user-attachments/assets/bf13f1ff-878a-4076-bb62-fce064d75c41" />

