### PR TITLE
[Fix] simplify login flow and improve Kakao OAuth redirect handling

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -40,7 +40,6 @@ export async function GET(request: Request) {
     console.error('[auth/callback] exchangeCodeForSession failed', {
       code: error.code,
       message: error.message,
-      status: error.status,
     });
     const loginUrl = new URL('/login', requestUrl.origin);
     loginUrl.searchParams.set('error', 'session_exchange_failed');

--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -97,6 +97,17 @@ export async function loginWithUserId(
   password: string
 ): Promise<LoginActionResult> {
   try {
+    if (
+      !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+      !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    ) {
+      console.error('[loginWithUserId] Missing required environment variables');
+      return {
+        success: false,
+        toast: errorToast('서버 설정 오류입니다. 관리자에게 문의하세요.'),
+      };
+    }
+
     const emailLookup = await lookupEmailByUserId(userId);
 
     if (!emailLookup.success || !emailLookup.email) {
@@ -117,7 +128,6 @@ export async function loginWithUserId(
     if (error || !data.session) {
       console.error('[loginWithUserId] signInWithPassword failed', {
         code: error?.code,
-        status: error?.status,
         message: error?.message,
       });
       return {

--- a/src/lib/supabase/index.ts
+++ b/src/lib/supabase/index.ts
@@ -1,7 +1,15 @@
 import { createBrowserClient } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+let supabaseInstance: SupabaseClient | null = null;
 
 export function createClient() {
-  return createBrowserClient(
+  // 싱글턴 패턴: 같은 인스턴스를 재사용
+  if (supabaseInstance) {
+    return supabaseInstance;
+  }
+
+  supabaseInstance = createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
@@ -11,4 +19,6 @@ export function createClient() {
       },
     }
   );
+
+  return supabaseInstance;
 }


### PR DESCRIPTION
## 📋 작업 내용
1. 500 로그인 에러: 환경변수 누락(NEXT_PUBLIC_SITE_URL) 및 로깅 개선
2. Kakao OAuth 리다이렉트 오류: localhost로 튀는 문제 해결
3. 로그인/로그아웃 후 헤더 갱신 에러: Supabase Singleton + 실시간 상태 동기화 구현

## 🎯 관련 이슈
Closes #58 

## 📝 변경사항
- src/lib/supabase/index.ts: Supabase 클라이언트 싱글턴 패턴 적용
- SupabaseAuthListener: onAuthStateChange 시 router.refresh()로 서버 컴포넌트 갱신
- LoginForm: 불필요한 setSession() 제거 → window.location.href로 리다이렉트 단순화
- login/actions.ts: 환경변수 검증, 에러 로깅 강화
- auth/callback/route.ts: OAuth 에러 로깅 개선

## ✅ 체크리스트
- 배포 전 확인:
	• Vercel 환경변수: NEXT_PUBLIC_SITE_URL=https://goatlife.app
	• NEXT_PUBLIC_SUPABASE_URL=https://vdiolcxwsdpsvxpwduos.supabase.co
- Supabase Auth → Site URL: https://goatlife.app
- 로그인/로그아웃 시 헤더 즉시 반영
- OAuth 로그인 시 goatlife.app으로 정상 리다이렉트
- 로그인 실패 시 에러 메시지 정상 표시

## 📸 스크린샷
