### PR TITLE
[Feat] Implement PerformanceWidget and integrate task view

### DIFF
--- a/src/app/_actions/tasks.ts
+++ b/src/app/_actions/tasks.ts
@@ -1,0 +1,218 @@
+'use server';
+
+import { createServerSupabase } from '@/lib/supabase/server';
+
+export type TaskStatus = 'todo' | 'in_progress' | 'done';
+
+export type Task = {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  order_index: number;
+  estimated_time: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type TasksResponse = { ok: true; data: Task[] } | { ok: false; error: string };
+
+type TaskResponse = { ok: true; data: Task } | { ok: false; error: string };
+
+type DeleteResponse = { ok: true; data: null } | { ok: false; error: string };
+
+async function getUserSupabaseClient() {
+  const supabase = await createServerSupabase();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return { ok: false as const, error: 'UNAUTHENTICATED' };
+  }
+
+  return { ok: true as const, supabase, user };
+}
+
+/**
+ * 상위 TODO 태스크 가져오기 (최대 4개)
+ */
+export async function getTopTodos(): Promise<TasksResponse> {
+  const client = await getUserSupabaseClient();
+  if (!client.ok) return client;
+
+  const { data, error } = await client.supabase
+    .from('tasks')
+    .select('*')
+    .eq('user_id', client.user.id)
+    .eq('status', 'todo')
+    .order('order_index', { ascending: true })
+    .order('created_at', { ascending: true })
+    .limit(4);
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  return { ok: true, data: (data as Task[]) ?? [] };
+}
+
+/**
+ * 모든 태스크 가져오기 (상태별 필터링 가능)
+ */
+export async function getTasks(status?: TaskStatus): Promise<TasksResponse> {
+  const client = await getUserSupabaseClient();
+  if (!client.ok) return client;
+
+  let query = client.supabase
+    .from('tasks')
+    .select('*')
+    .eq('user_id', client.user.id);
+
+  if (status) {
+    query = query.eq('status', status);
+  }
+
+  const { data, error } = await query
+    .order('order_index', { ascending: true })
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  return { ok: true, data: (data as Task[]) ?? [] };
+}
+
+/**
+ * 태스크 생성
+ */
+export async function createTask(input: {
+  title: string;
+  description?: string;
+  estimated_time?: string;
+}): Promise<TaskResponse> {
+  const client = await getUserSupabaseClient();
+  if (!client.ok) return client;
+
+  if (!input.title.trim()) {
+    return { ok: false, error: '제목을 입력해주세요.' };
+  }
+
+  const { data, error } = await client.supabase
+    .from('tasks')
+    .insert({
+      user_id: client.user.id,
+      title: input.title.trim(),
+      description: input.description?.trim() || null,
+      estimated_time: input.estimated_time || null,
+      status: 'todo',
+      order_index: 0,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  return { ok: true, data: data as Task };
+}
+
+/**
+ * 태스크 상태 변경
+ */
+export async function updateTaskStatus(
+  taskId: string,
+  status: TaskStatus
+): Promise<TaskResponse> {
+  const client = await getUserSupabaseClient();
+  if (!client.ok) return client;
+
+  const { data, error } = await client.supabase
+    .from('tasks')
+    .update({ status })
+    .eq('id', taskId)
+    .eq('user_id', client.user.id)
+    .select()
+    .single();
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  if (!data) {
+    return { ok: false, error: '태스크를 찾을 수 없습니다.' };
+  }
+
+  return { ok: true, data: data as Task };
+}
+
+/**
+ * 태스크 정보 업데이트
+ */
+export async function updateTask(
+  taskId: string,
+  updates: {
+    title?: string;
+    description?: string;
+    order_index?: number;
+    estimated_time?: string;
+  }
+): Promise<TaskResponse> {
+  const client = await getUserSupabaseClient();
+  if (!client.ok) return client;
+
+  if (updates.title !== undefined && !updates.title.trim()) {
+    return { ok: false, error: '제목을 입력해주세요.' };
+  }
+
+  const payload: Record<string, unknown> = {};
+  if (updates.title !== undefined) payload.title = updates.title.trim();
+  if (updates.description !== undefined)
+    payload.description = updates.description.trim() || null;
+  if (updates.order_index !== undefined)
+    payload.order_index = updates.order_index;
+  if (updates.estimated_time !== undefined)
+    payload.estimated_time = updates.estimated_time || null;
+
+  const { data, error } = await client.supabase
+    .from('tasks')
+    .update(payload)
+    .eq('id', taskId)
+    .eq('user_id', client.user.id)
+    .select()
+    .single();
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  if (!data) {
+    return { ok: false, error: '태스크를 찾을 수 없습니다.' };
+  }
+
+  return { ok: true, data: data as Task };
+}
+
+/**
+ * 태스크 삭제
+ */
+export async function deleteTask(taskId: string): Promise<DeleteResponse> {
+  const client = await getUserSupabaseClient();
+  if (!client.ok) return client;
+
+  const { error } = await client.supabase
+    .from('tasks')
+    .delete()
+    .eq('id', taskId)
+    .eq('user_id', client.user.id);
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  return { ok: true, data: null };
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,22 +1,13 @@
-/**
- * 홈 화면: 로그인 전/후 레이아웃 분기
- * - 게스트: 마케팅 배너(2칸) + 게시판1(공지) + 게시판2(커뮤니티) + 임원진 한마디 + Today 갓생이
- * - 회원: 근태관리, 사원정보, 게시판, 성과현황, 임원진 한마디, Today 갓생이
- */
 'use client';
-import { useState } from 'react';
 import { useAtomValue } from 'jotai';
 import dynamic from 'next/dynamic';
 import Button from '@/components/ui/Button';
-import TodoItem from '@/components/ui/TodoItem';
-import Toast from '@/components/ui/Toast';
 import Image from 'next/image';
 import { Icon } from '@iconify/react';
-import TodoDrawer from '@/components/TodoDrawer';
 import { userAtom } from '@/store/atoms';
 import UserInfoCard from '@/components/home/UserInfoCard';
+import PerformanceWidget from '@/components/home/PerformanceWidget';
 
-// AttendanceCard를 동적으로 로드 (성능 최적화)
 const AttendanceCard = dynamic(
   () => import('@/components/home/AttendanceCard'),
   {
@@ -43,68 +34,13 @@ export default function Home() {
   const user = useAtomValue(userAtom);
   const isMember = Boolean(user);
 
-  // 테스트용 Toast 상태
-  const [toast3, setToast3] = useState(false);
-
-  // 테스트용 Todo 상태
-  const [todos, setTodos] = useState([
-    { id: '1', text: '멋드러지게 숨쉬기', completed: false },
-    { id: '2', text: '죽여주는 점심식사하기', completed: false },
-    { id: '3', text: '끝내주게 산책하기', completed: false },
-    { id: '4', text: '고양이 밥주기', completed: false },
-  ]);
-
-  // Drawer 상태
-  const [drawerOpen, setDrawerOpen] = useState(false);
-  const [selectedTodo, setSelectedTodo] = useState<{
-    id: string;
-    text: string;
-    completed: boolean;
-  } | null>(null);
-
-  const handleToggle = (id: string) => {
-    setTodos(prev =>
-      prev.map(todo =>
-        todo.id === id ? { ...todo, completed: !todo.completed } : todo
-      )
-    );
-  };
-
-  const handleSettings = (id: string) => {
-    const todo = todos.find(t => t.id === id);
-    if (todo) {
-      setSelectedTodo(todo);
-      setDrawerOpen(true);
-    }
-  };
-
   return (
     <>
-      {/* Toasts */}
-      <Toast
-        show={toast3}
-        message="내 글에 새 댓글이 달렸어요"
-        type="info"
-        action={{
-          label: '보러가기',
-          onClick: () => {
-            alert('게시글로 이동!');
-            setToast3(false);
-          },
-        }}
-        onClose={() => setToast3(false)}
-      />
-
       {isMember ? (
-        /* ===================== 회원 레이아웃 ===================== */
         <>
-          {/* 근태관리 */}
           <AttendanceCard />
-
-          {/* 사원정보 */}
           <UserInfoCard />
 
-          {/* 게시판 */}
           <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[304px]">
             <div className="flex items-center gap-1 mb-4">
               <Icon
@@ -116,33 +52,10 @@ export default function Home() {
             <p className="body-base text-grey-700">최신 글</p>
           </section>
 
-          {/* 성과 현황 */}
-          <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[304px]">
-            <div className="flex items-center gap-1 mb-4">
-              <Icon
-                icon="icon-park:pie-seven"
-                className="w-6 h-6 text-primary-500"
-              />
-              <h2 className="brand-h3 text-grey-900">성과 현황</h2>
-            </div>
-            <div className="flex flex-col gap-3">
-              {todos.map(todo => (
-                <TodoItem
-                  key={todo.id}
-                  id={todo.id}
-                  text={todo.text}
-                  completed={todo.completed}
-                  onToggle={handleToggle}
-                  onSettings={handleSettings}
-                />
-              ))}
-            </div>
-          </section>
+          <PerformanceWidget mode="card" />
         </>
       ) : (
-        /* ===================== 게스트 레이아웃 ===================== */
         <>
-          {/* 마케팅 배너 (2칸) */}
           <section className="md:col-span-2 gl-bg-banner rounded-[5px] p-8 md:p-12 md:min-h-[176px] relative overflow-hidden">
             <div className="relative z-10 max-w-xl">
               <h2 className="brand-h2 text-grey-900 mb-4 leading-loose">
@@ -161,7 +74,6 @@ export default function Home() {
               </Button>
             </div>
 
-            {/* 말풍선 (Desktop only) */}
             <div className="hidden lg:flex absolute right-8 top-1/2 -translate-y-1/2">
               <Image
                 src="/images/speechBubble.svg"
@@ -173,7 +85,6 @@ export default function Home() {
             </div>
           </section>
 
-          {/* 게시판1 - 공지사항 */}
           <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[304px]">
             <div className="flex items-center gap-1 mb-4">
               <Icon
@@ -185,7 +96,6 @@ export default function Home() {
             <p className="body-base text-grey-700">최신 공지사항 불러오기...</p>
           </section>
 
-          {/* 게시판2 - 커뮤니티 */}
           <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[304px]">
             <div className="flex items-center gap-1 mb-4">
               <Icon
@@ -201,8 +111,6 @@ export default function Home() {
         </>
       )}
 
-      {/* ===================== 공통 섹션 ===================== */}
-      {/* 임원진 한마디 */}
       <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[210px]">
         <div className="flex items-center gap-1 mb-4">
           <Icon
@@ -216,7 +124,6 @@ export default function Home() {
         </p>
       </section>
 
-      {/* Today 갓생이 */}
       <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[210px]">
         <div className="flex items-center gap-1 mb-4">
           <Icon icon="icon-park:trophy" className="w-6 h-6 text-primary-500" />
@@ -224,13 +131,6 @@ export default function Home() {
         </div>
         <p className="body-base text-grey-700">1호 갓생이가 되어주세요🐹</p>
       </section>
-      {isMember && (
-        <TodoDrawer
-          isOpen={drawerOpen}
-          onClose={() => setDrawerOpen(false)}
-          todo={selectedTodo}
-        />
-      )}
     </>
   );
 }

--- a/src/components/home/PerformanceWidget.tsx
+++ b/src/components/home/PerformanceWidget.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useState } from 'react';
+import { Icon } from '@iconify/react';
+import TodoItem from '@/components/ui/TodoItem';
+import Toast from '@/components/ui/Toast';
+import TodoDrawer from '@/components/TodoDrawer';
+import { useTasks } from '@/hooks/useTasks';
+
+export interface PerformanceWidgetProps {
+  mode?: 'card' | 'page';
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function PerformanceWidget(props: PerformanceWidgetProps) {
+  const { lifecycle, items, toast, dismissToast, actions } = useTasks({
+    autoLoad: true,
+    limit: 4,
+  });
+
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+
+  const selectedTask = items.find(item => item.id === selectedTaskId);
+
+  const handleToggle = (id: string) => {
+    actions.markDone(id);
+  };
+
+  const handleSettings = (id: string) => {
+    setSelectedTaskId(id);
+    setDrawerOpen(true);
+  };
+
+  const handleSave = (data: {
+    id?: string;
+    title: string;
+    description: string;
+    estimatedTime: string;
+  }) => {
+    if (data.id) {
+      actions.update(data.id, {
+        title: data.title,
+        description: data.description,
+        estimated_time: data.estimatedTime,
+      });
+    }
+    setDrawerOpen(false);
+  };
+
+  const handleDelete = (id: string) => {
+    actions.remove(id);
+    setDrawerOpen(false);
+  };
+
+  // 로딩 스켈레톤
+  if (lifecycle === 'loading') {
+    return (
+      <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[304px]">
+        <div className="flex items-center gap-1 mb-4">
+          <Icon
+            icon="icon-park:pie-seven"
+            className="w-6 h-6 text-primary-500"
+          />
+          <h2 className="brand-h3 text-grey-900">성과 현황</h2>
+        </div>
+        <div className="flex flex-col gap-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="w-full h-12 bg-grey-300 rounded-lg animate-pulse"
+            />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  // 에러 상태
+  if (lifecycle === 'error') {
+    return (
+      <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[304px]">
+        <div className="flex items-center gap-1 mb-4">
+          <Icon
+            icon="icon-park:pie-seven"
+            className="w-6 h-6 text-primary-500"
+          />
+          <h2 className="brand-h3 text-grey-900">성과 현황</h2>
+        </div>
+        <div className="flex items-center justify-center h-40">
+          <p className="body-sm text-grey-500">
+            데이터를 불러오는 중 문제가 발생했어요.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  // 빈 상태
+  const isEmpty = items.length === 0;
+
+  return (
+    <>
+      <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[304px]">
+        <div className="flex items-center gap-1 mb-4">
+          <Icon
+            icon="icon-park:pie-seven"
+            className="w-6 h-6 text-primary-500"
+          />
+          <h2 className="brand-h3 text-grey-900">성과 현황</h2>
+        </div>
+
+        {isEmpty ? (
+          <div className="flex items-center justify-center h-40">
+            <p className="body-sm text-grey-500">
+              남아있는 업무계획이 없습니다.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {items.map(item => (
+              <TodoItem
+                key={item.id}
+                id={item.id}
+                text={item.title}
+                completed={false}
+                onToggle={handleToggle}
+                onSettings={handleSettings}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {toast && (
+        <Toast
+          show={true}
+          message={toast.message}
+          type={toast.type}
+          onClose={dismissToast}
+        />
+      )}
+
+      <TodoDrawer
+        isOpen={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        todo={
+          selectedTask
+            ? {
+                id: selectedTask.id,
+                text: selectedTask.title,
+                description: selectedTask.description || undefined,
+              }
+            : null
+        }
+        onSave={handleSave}
+        onDelete={handleDelete}
+      />
+    </>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -26,12 +26,12 @@ export default function Footer() {
 
       <div className="flex items-center gap-4 flex-shrink-0">
         <SocialIcon
-          href="https://instagram.com/goatlife"
+          href="https://www.instagram.com/goatlife.app/"
           icon="/images/icons/icon-instagram.svg"
           alt="Instagram"
         />
         <SocialIcon
-          href="https://x.com/goatlife"
+          href="https://x.com/GoatlifeApp"
           icon="/images/icons/icon-twitter.svg"
           alt="X (Twitter)"
         />

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,0 +1,227 @@
+'use client';
+
+import { useCallback, useEffect, useState, useTransition } from 'react';
+import {
+  fetchTopTodos,
+  changeTaskStatus,
+  modifyTask,
+  removeTask,
+  type Task,
+} from '@/services/tasks';
+
+export type TasksLifecycle = 'idle' | 'loading' | 'ready' | 'error';
+export type ToastState = { message: string; type: 'success' | 'error' } | null;
+
+export interface UseTasksOptions {
+  autoLoad?: boolean;
+  limit?: number; // 최대 개수 제한 (기본 4)
+}
+
+export interface UseTasksResult {
+  lifecycle: TasksLifecycle;
+  items: Task[];
+  isLoading: boolean;
+  isMutating: boolean;
+  error: string | null;
+  toast: ToastState;
+  dismissToast: () => void;
+  refresh: () => Promise<void>;
+  actions: {
+    markDone: (taskId: string) => void;
+    update: (
+      taskId: string,
+      updates: {
+        title?: string;
+        description?: string;
+        estimated_time?: string;
+      }
+    ) => void;
+    remove: (taskId: string) => void;
+  };
+}
+
+export function useTasks(options: UseTasksOptions = {}): UseTasksResult {
+  const { autoLoad = true, limit = 4 } = options;
+
+  const [lifecycle, setLifecycle] = useState<TasksLifecycle>('idle');
+  const [items, setItems] = useState<Task[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [toast, setToast] = useState<ToastState>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const showToast = useCallback(
+    (message: string, type: 'success' | 'error') => {
+      setToast({ message, type });
+    },
+    []
+  );
+
+  const dismissToast = useCallback(() => setToast(null), []);
+
+  const loadInitial = useCallback(async () => {
+    setLifecycle('loading');
+    setError(null);
+
+    try {
+      const result = await fetchTopTodos();
+
+      if (result.ok) {
+        const todoItems = result.data.filter(item => item.status === 'todo');
+        setItems(todoItems.slice(0, limit));
+        setLifecycle('ready');
+      } else if (result.error === 'UNAUTHENTICATED') {
+        setError('UNAUTHENTICATED');
+        setLifecycle('error');
+      } else {
+        showToast('업무계획서를 불러오지 못했어요.', 'error');
+        setError(result.error);
+        setLifecycle('error');
+      }
+    } catch {
+      setLifecycle('error');
+      setError('UNKNOWN');
+      showToast('업무계획서를 불러오는 중 문제가 발생했어요.', 'error');
+    }
+  }, [limit, showToast]);
+
+  useEffect(() => {
+    if (!autoLoad) return;
+    void loadInitial();
+  }, [autoLoad, loadInitial]);
+
+  /**
+   * 완료 처리 (done으로 변경 → 리스트에서 제거)
+   */
+  const handleMarkDone = useCallback(
+    (taskId: string) => {
+      if (isPending) return;
+
+      const taskToRemove = items.find(item => item.id === taskId);
+      if (!taskToRemove) return;
+
+      // 낙관적 업데이트: 리스트에서 즉시 제거
+      const optimisticItems = items.filter(item => item.id !== taskId);
+      setItems(optimisticItems);
+
+      startTransition(() => {
+        void (async () => {
+          const result = await changeTaskStatus(taskId, 'done');
+          if (!result.ok) {
+            // 실패시 롤백
+            setItems(items);
+            const message =
+              result.error === 'UNAUTHENTICATED'
+                ? '로그인이 필요해요.'
+                : '완료 처리에 실패했어요. 잠시 후 다시 시도해주세요.';
+            showToast(message, 'error');
+            return;
+          }
+
+          // 성공
+          showToast('업무 완료!', 'success');
+        })();
+      });
+    },
+    [items, isPending, showToast]
+  );
+
+  /**
+   * 태스크 정보 업데이트
+   */
+  const handleUpdate = useCallback(
+    (
+      taskId: string,
+      updates: {
+        title?: string;
+        description?: string;
+        estimated_time?: string;
+      }
+    ) => {
+      if (isPending) return;
+
+      const originalItems = items;
+
+      // 낙관적 업데이트
+      const optimisticItems = items.map(item =>
+        item.id === taskId ? { ...item, ...updates } : item
+      );
+      setItems(optimisticItems);
+
+      startTransition(() => {
+        void (async () => {
+          const result = await modifyTask(taskId, updates);
+          if (!result.ok) {
+            // 실패시 롤백
+            setItems(originalItems);
+            const message =
+              result.error === 'UNAUTHENTICATED'
+                ? '로그인이 필요해요.'
+                : '업데이트에 실패했어요.';
+            showToast(message, 'error');
+            return;
+          }
+
+          // 성공: 서버 데이터로 동기화
+          setItems(prevItems =>
+            prevItems.map(item =>
+              item.id === taskId ? (result.data as Task) : item
+            )
+          );
+          showToast('저장 완료!', 'success');
+        })();
+      });
+    },
+    [items, isPending, showToast]
+  );
+
+  /**
+   * 태스크 삭제
+   */
+  const handleRemove = useCallback(
+    (taskId: string) => {
+      if (isPending) return;
+
+      const originalItems = items;
+
+      // 낙관적 업데이트: 리스트에서 즉시 제거
+      const optimisticItems = items.filter(item => item.id !== taskId);
+      setItems(optimisticItems);
+
+      startTransition(() => {
+        void (async () => {
+          const result = await removeTask(taskId);
+          if (!result.ok) {
+            // 실패시 롤백
+            setItems(originalItems);
+            const message =
+              result.error === 'UNAUTHENTICATED'
+                ? '로그인이 필요해요.'
+                : '삭제에 실패했어요.';
+            showToast(message, 'error');
+            return;
+          }
+
+          // 성공
+          showToast('삭제 완료!', 'success');
+        })();
+      });
+    },
+    [items, isPending, showToast]
+  );
+
+  return {
+    lifecycle,
+    items,
+    isLoading: lifecycle === 'loading',
+    isMutating: isPending,
+    error,
+    toast,
+    dismissToast,
+    refresh: loadInitial,
+    actions: {
+      markDone: handleMarkDone,
+      update: handleUpdate,
+      remove: handleRemove,
+    },
+  };
+}

--- a/src/services/tasks.ts
+++ b/src/services/tasks.ts
@@ -1,0 +1,126 @@
+import {
+  getTopTodos as serverGetTopTodos,
+  getTasks as serverGetTasks,
+  createTask as serverCreateTask,
+  updateTaskStatus as serverUpdateTaskStatus,
+  updateTask as serverUpdateTask,
+  deleteTask as serverDeleteTask,
+  type Task,
+  type TaskStatus,
+} from '@/app/_actions/tasks';
+
+const DEFAULT_TIMEOUT = 3000;
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs = DEFAULT_TIMEOUT) {
+  return Promise.race<T>([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error('Request timeout')), timeoutMs)
+    ),
+  ]);
+}
+
+type TasksResult<T> = { ok: true; data: T } | { ok: false; error: string };
+
+export type { Task, TaskStatus };
+
+/**
+ * 상위 TODO 태스크 가져오기 (최대 4개)
+ */
+export async function fetchTopTodos(): Promise<TasksResult<Task[]>> {
+  try {
+    const result = await withTimeout(serverGetTopTodos());
+    return result.ok
+      ? { ok: true, data: result.data ?? [] }
+      : { ok: false, error: result.error };
+  } catch {
+    return { ok: false, error: 'UNKNOWN' };
+  }
+}
+
+/**
+ * 모든 태스크 가져오기 (상태별 필터링 가능)
+ */
+export async function fetchTasks(
+  status?: TaskStatus
+): Promise<TasksResult<Task[]>> {
+  try {
+    const result = await withTimeout(serverGetTasks(status));
+    return result.ok
+      ? { ok: true, data: result.data ?? [] }
+      : { ok: false, error: result.error };
+  } catch {
+    return { ok: false, error: 'UNKNOWN' };
+  }
+}
+
+/**
+ * 태스크 생성
+ */
+export async function createNewTask(input: {
+  title: string;
+  description?: string;
+  estimated_time?: string;
+}): Promise<TasksResult<Task>> {
+  try {
+    const result = await withTimeout(serverCreateTask(input));
+    return result.ok
+      ? { ok: true, data: result.data }
+      : { ok: false, error: result.error };
+  } catch {
+    return { ok: false, error: 'UNKNOWN' };
+  }
+}
+
+/**
+ * 태스크 상태 변경
+ */
+export async function changeTaskStatus(
+  taskId: string,
+  status: TaskStatus
+): Promise<TasksResult<Task>> {
+  try {
+    const result = await withTimeout(serverUpdateTaskStatus(taskId, status));
+    return result.ok
+      ? { ok: true, data: result.data }
+      : { ok: false, error: result.error };
+  } catch {
+    return { ok: false, error: 'UNKNOWN' };
+  }
+}
+
+/**
+ * 태스크 정보 업데이트
+ */
+export async function modifyTask(
+  taskId: string,
+  updates: {
+    title?: string;
+    description?: string;
+    order_index?: number;
+    estimated_time?: string;
+  }
+): Promise<TasksResult<Task>> {
+  try {
+    const result = await withTimeout(serverUpdateTask(taskId, updates));
+    return result.ok
+      ? { ok: true, data: result.data }
+      : { ok: false, error: result.error };
+  } catch {
+    return { ok: false, error: 'UNKNOWN' };
+  }
+}
+
+/**
+ * 태스크 삭제
+ */
+export async function removeTask(taskId: string): Promise<TasksResult<null>> {
+  try {
+    const result = await withTimeout(serverDeleteTask(taskId));
+    return result.ok
+      ? { ok: true, data: null }
+      : { ok: false, error: result.error };
+  } catch {
+    return { ok: false, error: 'UNKNOWN' };
+  }
+}

--- a/supabase-attendance-setup.sql
+++ b/supabase-attendance-setup.sql
@@ -267,11 +267,3 @@ GRANT EXECUTE ON FUNCTION public.fn_clock_in TO authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_early_leave TO authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_clock_out TO authenticated;
 
--- ============================================================================
--- 완료!
--- ============================================================================
--- 이제 다음 단계를 진행하세요:
--- 1. Supabase SQL Editor에서 이 스크립트를 복사하여 실행
--- 2. 실행 후 에러가 없는지 확인
--- 3. 애플리케이션에서 출근/퇴근 기능 테스트
--- ============================================================================

--- a/supabase-backfill-oauth-profiles.sql
+++ b/supabase-backfill-oauth-profiles.sql
@@ -1,5 +1,4 @@
 -- OAuth 사용자 기본값 보정 스크립트
--- Supabase SQL Editor에서 실행하세요.
 
 update public.profiles
 set

--- a/supabase-rls-policies.sql
+++ b/supabase-rls-policies.sql
@@ -1,5 +1,4 @@
 -- Supabase RLS Policies for profiles table
--- Run this in Supabase Dashboard → SQL Editor
 
 -- 1. 회원가입 시 새 프로필 생성 허용
 CREATE POLICY "Enable insert for authenticated users"

--- a/supabase-tasks-setup.sql
+++ b/supabase-tasks-setup.sql
@@ -1,0 +1,80 @@
+-- ================================================
+-- 업무계획(칸반) Tasks 테이블 및 뷰 설정
+-- ================================================
+
+-- 1. tasks 테이블 생성
+create table if not exists public.tasks (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  title text not null,
+  description text,
+  status text not null check (status in ('todo','in_progress','done')) default 'todo',
+  order_index int not null default 0,
+  estimated_time text, -- 예상 포모도로 개수 (예: '2')
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- 2. 인덱스 생성 (성능 최적화)
+create index if not exists idx_tasks_user_id on public.tasks(user_id);
+create index if not exists idx_tasks_user_status on public.tasks(user_id, status);
+create index if not exists idx_tasks_user_order on public.tasks(user_id, order_index);
+
+-- 3. updated_at 자동 업데이트 함수 (이미 있으면 재사용)
+create or replace function public.fn_touch_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+-- 4. updated_at 트리거
+drop trigger if exists trg_tasks_touch on public.tasks;
+create trigger trg_tasks_touch
+  before update on public.tasks
+  for each row
+  execute function public.fn_touch_updated_at();
+
+-- 5. RLS 활성화
+alter table public.tasks enable row level security;
+
+-- 6. RLS 정책: 자신의 태스크만 조회 가능
+drop policy if exists "tasks_select_own" on public.tasks;
+create policy "tasks_select_own" on public.tasks
+  for select
+  using (auth.uid() = user_id);
+
+-- 7. RLS 정책: 자신의 태스크만 삽입 가능
+drop policy if exists "tasks_insert_own" on public.tasks;
+create policy "tasks_insert_own" on public.tasks
+  for insert
+  with check (auth.uid() = user_id);
+
+-- 8. RLS 정책: 자신의 태스크만 수정 가능
+drop policy if exists "tasks_update_own" on public.tasks;
+create policy "tasks_update_own" on public.tasks
+  for update
+  using (auth.uid() = user_id);
+
+-- 9. RLS 정책: 자신의 태스크만 삭제 가능
+drop policy if exists "tasks_delete_own" on public.tasks;
+create policy "tasks_delete_own" on public.tasks
+  for delete
+  using (auth.uid() = user_id);
+
+-- 10. 뷰: 홈 카드용 (todo 상태 최대 4개)
+create or replace view public.v_tasks_todo_top4
+with (security_invoker = true) as
+select
+  id,
+  title,
+  description,
+  status,
+  order_index,
+  estimated_time,
+  created_at
+from public.tasks
+where user_id = auth.uid() and status = 'todo'
+order by order_index asc, created_at asc
+limit 4;

--- a/supabase-user-summary.sql
+++ b/supabase-user-summary.sql
@@ -1,6 +1,5 @@
 -- ============================================================================
 -- 갓생상사 사원 정보 요약 뷰 및 정책
--- 실행 위치: Supabase SQL Editor
 -- 목적:
 --   - profiles 테이블 기반으로 홈 화면 사원 정보 요약 데이터를 제공
 --   - joined_days, performance_rate 등의 파생 컬럼 계산
@@ -41,14 +40,3 @@ alter view public.v_user_summary set (security_invoker = on);
 
 -- 선택: 인증 사용자에게 자신의 행만 조회 허용
 -- (RLS와 함께 사용 시 보조 정책으로 활용)
-/*
-create policy "view_user_summary_current"
-  on public.v_user_summary
-  for select
-  using (auth.uid() = user_id);
-*/
-
--- ============================================================================
--- 실행 후 확인
--- select * from public.v_user_summary where user_id = auth.uid();
--- ============================================================================


### PR DESCRIPTION
## 📋 작업 내용
- Supabase DB 구조 추가
	- supabase-tasks-setup.sql
	- tasks 테이블 생성 (title, description, status, order_index 등)
	- RLS 정책 설정 및 v_tasks_todo_top4 뷰 생성
- 서버 액션 및 서비스 레이어
	- getTopTodos, updateTaskStatus, deleteTask 등 구현
	- 공통 에러 핸들링 및 타임아웃 로직 추가
- 커스텀 훅 (useTasks.ts)
	- 낙관적 업데이트 + 실패 시 롤백
	- Toast 기반 피드백
- UI 컴포넌트 (PerformanceWidget.tsx)
	- 최대 4개의 TODO 표시
	- 완료 시 즉시 카드에서 제거
	- Hover 시 설정 아이콘 → Modal 편집/삭제 가능
	- 로딩, 빈 상태, 에러 처리 추가
- 홈 페이지 통합 (page.tsx)
	- 기존 더미 “성과현황” 섹션을 <PerformanceWidget /> 로 대체

## 🎯 관련 이슈
Closes #39 

## 📝 변경사항
- 상기 작업내용 관련 파일
- added footer social media links, removed sql files comments

## ✅ 체크리스트
- [ ] 코드 리뷰 받을 준비 완료
- [ ] 테스트 완료 
- [ ] 문서 업데이트 (필요시)

## 📸 스크린샷
<img width="1217" height="629" alt="Screenshot 2025-11-06 at 23 00 31" src="https://github.com/user-attachments/assets/e88c9145-1637-40e6-902a-ea1f7e415416" />
