### PR TITLE
[Refactor(auth)] stabilize Kakao OAuth flow & clean logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ pnpm install
 # 개발 서버 실행
 pnpm run dev
 
-### Supabase Auth 설정 (개발 환경)
+### Supabase Auth & OAuth 설정
 - Supabase Dashboard → Authentication → Providers → Email에서 **Enable Email provider**를 ON으로 설정하세요.
 - 개발 환경에서는 **Confirm email**을 OFF로 두고, 필요 시 Supabase SQL Editor에서 아래 쿼리로 테스트 계정을 인증 처리할 수 있습니다.
 
@@ -88,6 +88,24 @@ WHERE email_confirmed_at IS NULL;
   - 프로덕션: `https://vdiolcxwsdpsvxpwduos.supabase.co/auth/v1/callback`
   - 개발(로컬): `http://localhost:3000/auth/callback` (또는 실제 사용 중인 로컬 도메인)
   - `.env.local` 파일에 `NEXT_PUBLIC_SITE_URL=https://your-domain.com` 값을 설정하면 OAuth가 해당 도메인으로 리다이렉트됩니다.
+- Kakao Client Secret을 발급받은 경우 Supabase Dashboard → Authentication → Providers → Kakao에서 REST API 키와 함께 Client Secret을 입력하고 **사용함** 상태로 저장하세요. Secret을 재발급한 경우 즉시 해당 값을 갱신해야 합니다.
+- 기존 OAuth 사용자 프로필의 `last_name` 또는 `rank`가 비어 있다면 `supabase-backfill-oauth-profiles.sql` 스크립트를 SQL Editor에서 실행해 기본값을 채워주세요.
+- 로컬/배포 환경 변수 권장값
+  - `.env.local`
+    ```
+    NEXT_PUBLIC_SITE_URL=http://localhost:3000
+    NEXT_PUBLIC_SUPABASE_URL=...
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+    SUPABASE_SERVICE_ROLE_KEY=...
+    ```
+  - Vercel(Production)
+    ```
+    NEXT_PUBLIC_SITE_URL=https://goatlife.app
+    NEXT_PUBLIC_SUPABASE_URL=...
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+    SUPABASE_SERVICE_ROLE_KEY=...
+    ```
+  - Supabase Auth → Site URL에는 프로덕션 도메인을, Kakao Developers에서는 Local/Prod 두 도메인을 모두 등록하세요.
 - Kakao Client Secret을 발급받은 경우 Supabase Dashboard → Authentication → Providers → Kakao에서 REST API 키와 함께 Client Secret을 입력하고 **사용함** 상태로 저장하세요. Secret을 재발급한 경우 즉시 해당 값을 갱신해야 합니다.
 - 기존 OAuth 사용자 프로필의 `last_name` 또는 `rank`가 비어 있다면 `supabase-backfill-oauth-profiles.sql` 스크립트를 SQL Editor에서 실행해 기본값을 채워주세요.
 
@@ -189,4 +207,4 @@ pnpm install
 
 # Run development server
 pnpm run dev
-🎉Deployed to https://goatlife.app 🍀
+```

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,5 +1,131 @@
 import { NextResponse } from 'next/server';
 import { createServerSupabase } from '@/lib/supabase/server';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const dynamic = 'force-dynamic';
+
+const DEFAULT_DEPARTMENT = 'IT부';
+const DEFAULT_WORK_HOURS = '주간(09:00-18:00)';
+const DEFAULT_WORK_TYPE = '풀타임';
+const DEFAULT_RANK = '인턴';
+
+const sanitizeHandle = (raw: string | null | undefined) => {
+  if (!raw) return null;
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) return null;
+  const sanitized = trimmed.replace(/[^a-z0-9_-]/g, '');
+  return sanitized || null;
+};
+
+const getEmailLocalPart = (email?: string | null) => {
+  if (!email) return null;
+  const [local] = email.split('@');
+  return sanitizeHandle(local);
+};
+
+async function generateUserId(
+  supabase: SupabaseClient,
+  baseCandidates: (string | null | undefined)[]
+) {
+  const candidates = baseCandidates
+    .map(candidate => sanitizeHandle(candidate ?? undefined))
+    .filter(Boolean) as string[];
+
+  if (candidates.length === 0) {
+    candidates.push(`gl${Math.random().toString(36).slice(2, 8)}`);
+  }
+
+  for (const base of candidates) {
+    const available = await findAvailableHandle(supabase, base);
+    if (available) {
+      return available;
+    }
+  }
+
+  return `gl${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function findAvailableHandle(supabase: SupabaseClient, base: string) {
+  let attempt = 0;
+  while (attempt < 5) {
+    const candidate = attempt === 0 ? base : `${base}-${attempt}`;
+    const { data } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('user_id', candidate)
+      .maybeSingle();
+
+    if (!data) {
+      return candidate;
+    }
+    attempt += 1;
+  }
+  return null;
+}
+
+async function ensureProfile(supabase: SupabaseClient) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return;
+  }
+
+  const { data: existingProfile } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  if (existingProfile) {
+    return;
+  }
+
+  const metadata = user.user_metadata ?? {};
+  const email =
+    user.email ??
+    (metadata['account_email'] as string | undefined) ??
+    (metadata['email'] as string | undefined) ??
+    null;
+
+  const nickname =
+    (metadata['profile_nickname'] as string | undefined) ??
+    (metadata['nickname'] as string | undefined) ??
+    null;
+
+  const generatedUserId = await generateUserId(supabase, [
+    getEmailLocalPart(email),
+    nickname,
+    user.id.replace(/-/g, ''),
+  ]);
+
+  const payload = {
+    id: user.id,
+    user_id: generatedUserId,
+    email,
+    last_name: nickname ?? generatedUserId,
+    first_name: null,
+    rank: DEFAULT_RANK,
+    department: DEFAULT_DEPARTMENT,
+    work_hours: DEFAULT_WORK_HOURS,
+    work_type: DEFAULT_WORK_TYPE,
+    work_style: metadata['work_style'] ?? null,
+    work_ethic: metadata['work_ethic'] ?? null,
+    avatar_url:
+      (metadata['avatar_url'] as string | undefined) ??
+      (metadata['picture'] as string | undefined) ??
+      null,
+  };
+
+  const { error: insertError } = await supabase
+    .from('profiles')
+    .insert(payload);
+
+  if (insertError) {
+    console.error('[auth/callback] profile upsert failed', insertError);
+  }
+}
 
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url);
@@ -23,14 +149,14 @@ export async function GET(request: Request) {
     console.error('[auth/callback] provider error', errorDescription);
     const loginUrl = new URL('/login', requestUrl.origin);
     loginUrl.searchParams.set('error', 'oauth_failed');
-    return NextResponse.redirect(loginUrl);
+    return NextResponse.redirect(loginUrl, { status: 303 });
   }
 
   if (!code) {
     console.error('[auth/callback] missing auth code');
     const loginUrl = new URL('/login', requestUrl.origin);
     loginUrl.searchParams.set('error', 'missing_code');
-    return NextResponse.redirect(loginUrl);
+    return NextResponse.redirect(loginUrl, { status: 303 });
   }
 
   const supabase = await createServerSupabase();
@@ -43,8 +169,13 @@ export async function GET(request: Request) {
     });
     const loginUrl = new URL('/login', requestUrl.origin);
     loginUrl.searchParams.set('error', 'session_exchange_failed');
-    return NextResponse.redirect(loginUrl);
+    return NextResponse.redirect(loginUrl, { status: 303 });
   }
 
-  return NextResponse.redirect(new URL(redirectDestination, requestUrl.origin));
+  await ensureProfile(supabase);
+
+  return NextResponse.redirect(
+    new URL(redirectDestination, requestUrl.origin),
+    { status: 303 }
+  );
 }

--- a/src/components/features/auth/LoginForm.tsx
+++ b/src/components/features/auth/LoginForm.tsx
@@ -54,16 +54,19 @@ export default function LoginForm() {
   });
 
   const getOAuthRedirectTo = () => {
-    if (typeof window === 'undefined') {
-      return undefined;
+    if (typeof window !== 'undefined') {
+      const origin = window.location.origin.replace(/\/$/, '');
+
+      if (/localhost(:\d+)?$/.test(window.location.host)) {
+        return `${origin}/auth/callback`;
+      }
+
+      const site = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '');
+      return `${site || origin}/auth/callback`;
     }
 
-    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '');
-    if (siteUrl) {
-      return `${siteUrl}/auth/callback`;
-    }
-
-    return `${window.location.origin}/auth/callback`;
+    const site = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '');
+    return site ? `${site}/auth/callback` : undefined;
   };
 
   const onSubmit = async ({ userId, password }: LoginForm) => {
@@ -79,10 +82,8 @@ export default function LoginForm() {
       }
 
       setToast(result.toast);
-
-      // 짧은 딜레이 후 전체 페이지 새로고침으로 홈 이동
-      await new Promise(resolve => setTimeout(resolve, 500));
-      window.location.href = '/';
+      router.replace('/');
+      router.refresh();
     } catch (error) {
       console.error('[LoginForm] unexpected login error', error);
       setToast({
@@ -190,6 +191,7 @@ export default function LoginForm() {
           className="mb-6 bg-yellow-300 text-fixed-grey-900 hover:bg-yellow-400 disabled:opacity-50"
           disabled={isKakaoLoading || isPasswordLoginLoading}
           onClick={handleKakaoLogin}
+          data-testid="kakao-login-button"
         >
           {isKakaoLoading ? '카카오 로그인 중...' : '카카오톡으로 로그인'}
         </Button>

--- a/src/services/attendance.ts
+++ b/src/services/attendance.ts
@@ -8,7 +8,7 @@ import {
   type AttendanceStatus,
 } from '@/app/_actions/attendance';
 
-const DEFAULT_TIMEOUT = 3000;
+const DEFAULT_TIMEOUT = 6000;
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs = DEFAULT_TIMEOUT) {
   return Promise.race<T>([

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -10,4 +10,5 @@ export interface User {
   department?: string;
   userId?: string;
   provider?: string;
+  joinedAt?: string;
 }


### PR DESCRIPTION
## 📋 작업 내용
- 로컬에서 카카오 로그인 시 프로덕션으로 리다이렉트되거나, /auth/callback 이후 세션이 반영되지 않는 이슈가 간헐적으로 발생: 원인은 Supabase OAuth Redirect URL 설정 불일치(로컬/프로덕션)와 콜백 라우트의 동적 처리/리다이렉트 부족.
-> Kakao OAuth가 로컬/프로덕션에서 일관되게 동작하도록 /auth/callback 동적 처리 + 303 리다이렉트 적용, redirectTo를 환경변수로 단일화하고 디버깅 로그를 정리
- 카카오 OAuth 로그인 이후 profiles가 아직 생성되지 않은 사용자에게도 정상적으로 닉네임/아이디가 표시되도록 개선 -> 헤더, 사원정보 카드에서 모두 동일한 닉네임·직급·아바타를 보여줌(**work_hours, work_type Badge는 출력 불가**)
- 카카오 계정도 “0일차” 대신 최소 1일차부터 입사일 계산

 **환경 변수 & 콘솔 설정:**
- 로컬 .env.local: NEXT_PUBLIC_SITE_URL=http://localhost:3000
- Vercel (Production): NEXT_PUBLIC_SITE_URL=https://goatlife.app
- Supabase Authentication → URL Configuration(Redirect URLs에 아래 두 개 등록):  
	- http://localhost:3000/auth/callback
	- https://goatlife.app/auth/callback

## 🎯 관련 이슈
Closes #62 

## 📝 변경사항
- Supabase OAuth 연동 안정화
	- /auth/callback에 export const dynamic = 'force-dynamic' 적용
	- 모든 리다이렉트에 { status: 303 } 명시 → GET 리다이렉트로 일관화
	- redirectTo를 환경변수 NEXT_PUBLIC_SITE_URL 기반으로 단일화(하드코딩 제거)
- 로그 정리
	- LoginForm.tsx에서 디버깅 console.log/주석 제거 (에러 로깅 console.error만 유지)
	- README 불필요 라인 제거
- Side effects
	- 로컬/프로덕션 전환 시 로그인 흐름 예측 가능성 향상
	- 콘솔 노이즈 감소로 유지보수성 개선

<User Profile Fallback & Nickname Display>
- 세션 하이드레이션 시 nickname, derived user_id, joinedAt 등 추가 메타데이터 저장
- v_user_summary_self가 데이터를 반환하지 않는 경우(예: 카카오 신규 유저)
	- 클라이언트 세션의 user 메타데이터로 fallback
- joinedDays는 최소 1일부터 계산되며, @id는 이메일 로컬파트 기반 자동 생성(**중복되는 회원 발생가능한 문제도 있으니 uuid로 사용금지 및 랜덤 id값 생성 로직 추후 고려**)

## ✅ 체크리스트
- [ ] 코드 리뷰 받을 준비 완료
- [ ] 테스트 완료 
- [ ] 문서 업데이트 (필요시)

## 📸 스크린샷
<img width="908" height="294" alt="Screenshot 2025-11-08 at 17 27 20" src="https://github.com/user-attachments/assets/70572d2a-e5d9-4236-8142-986ace0cca1d" />
