### PR TITLE
[Feat] implement Exec Message Section

### DIFF
--- a/src/app/_actions/execMessage.ts
+++ b/src/app/_actions/execMessage.ts
@@ -1,0 +1,53 @@
+'use server';
+
+import { createServerSupabase } from '@/lib/supabase/server';
+
+export type ExecMessage = {
+  id: string;
+  authorName: string | null;
+  authorTitle: string | null;
+  avatarUrl: string | null;
+  message: string;
+  lang: string | null;
+  createdAt: string;
+  isExplicit: boolean;
+};
+
+export type ExecMessageResult =
+  | { ok: true; data: ExecMessage }
+  | { ok: false; error: string };
+
+export async function getCurrentExecMessage(): Promise<ExecMessageResult> {
+  try {
+    const supabase = await createServerSupabase();
+    const { data, error } = await supabase
+      .from('v_exec_message_current_or_quote')
+      .select('*')
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+
+    if (!data) {
+      return { ok: false, error: 'NO_MESSAGE' };
+    }
+
+    return {
+      ok: true,
+      data: {
+        id: data.id,
+        authorName: data.author_name ?? null,
+        authorTitle: data.author_title ?? null,
+        avatarUrl: data.avatar_url ?? null,
+        message: data.message,
+        lang: data.lang ?? null,
+        createdAt: data.created_at,
+        isExplicit: data.is_explicit_message ?? false,
+      },
+    };
+  } catch (e) {
+    console.error('[getCurrentExecMessage] failed', e);
+    return { ok: false, error: 'UNKNOWN' };
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { Icon } from '@iconify/react';
 import { userAtom } from '@/store/atoms';
 import UserInfoCard from '@/components/home/UserInfoCard';
+import ExecMessageCard from '@/components/home/ExecMessageCard';
 import PerformanceWidget from '@/components/home/PerformanceWidget';
 
 const AttendanceCard = dynamic(
@@ -111,18 +112,7 @@ export default function Home() {
         </>
       )}
 
-      <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[210px]">
-        <div className="flex items-center gap-1 mb-4">
-          <Icon
-            icon="icon-park:relieved-face"
-            className="w-6 h-6 text-primary-500"
-          />
-          <h2 className="brand-h3 text-grey-900">임원진 한마디</h2>
-        </div>
-        <p className="body-base text-grey-700">
-          &quot;일찍 일어나는 벌레는 오운완해서 잽싸게 도망간다.&quot;
-        </p>
-      </section>
+      <ExecMessageCard />
 
       <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[210px]">
         <div className="flex items-center gap-1 mb-4">

--- a/src/components/home/ExecMessageCard.tsx
+++ b/src/components/home/ExecMessageCard.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import ExecMessageView from '@/components/shared/ExecMessageView';
+import { useExecMessage } from '@/hooks/useExecMessage';
+
+export default function ExecMessageCard() {
+  const { lifecycle, data, error } = useExecMessage({ autoLoad: true });
+
+  return (
+    <ExecMessageView
+      lifecycle={lifecycle}
+      data={data}
+      error={error}
+      mode="compact"
+    />
+  );
+}

--- a/src/components/shared/ExecMessageView.tsx
+++ b/src/components/shared/ExecMessageView.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import Avatar from '@/components/ui/Avatar';
+import { Icon } from '@iconify/react';
+import type { ExecMessage } from '@/app/_actions/execMessage';
+import type { ExecMessageLifecycle } from '@/hooks/useExecMessage';
+
+interface ExecMessageViewProps {
+  lifecycle: ExecMessageLifecycle;
+  data: ExecMessage | null;
+  error?: string | null;
+  mode?: 'compact' | 'full';
+}
+
+function Skeleton() {
+  return (
+    <div className="grid grid-cols-[64px_1fr] md:grid-cols-[80px_1fr] gap-2 md:gap-2">
+      <div className="size-16 md:size-20 rounded-full bg-grey-300 animate-pulse" />
+      <div className="space-y-2">
+        <div className="h-4 w-28 bg-grey-300 rounded animate-pulse" />
+        <div className="h-3 w-16 bg-grey-200 rounded animate-pulse" />
+        <div className="h-20 bg-white rounded-[5px] shadow animate-pulse" />
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return <p className="body-sm text-grey-500">{message}</p>;
+}
+
+export default function ExecMessageView({
+  lifecycle,
+  data,
+  error,
+  mode = 'compact',
+}: ExecMessageViewProps) {
+  const badgeText = data ? (data.isExplicit ? '공지' : '명언') : null;
+
+  return (
+    <section
+      className="bg-grey-100 rounded-[5px] p-6"
+      aria-labelledby="exec-message-title"
+    >
+      <div className="flex items-end gap-1 mb-4">
+        <Icon
+          icon="icon-park:relieved-face"
+          className="w-6 h-6 text-primary-500"
+          aria-hidden="true"
+        />
+        <h2 id="exec-message-title" className="brand-h3 text-grey-900">
+          임원진 한마디
+        </h2>
+      </div>
+
+      {lifecycle === 'loading' && <Skeleton />}
+
+      {lifecycle === 'error' && (
+        <EmptyState
+          message={
+            error === 'NO_MESSAGE'
+              ? '등록된 메시지가 없습니다.'
+              : '메시지를 불러오지 못했어요.'
+          }
+        />
+      )}
+
+      {lifecycle === 'success' && !data && (
+        <EmptyState message="등록된 메시지가 없습니다." />
+      )}
+
+      {lifecycle === 'success' && data && (
+        <div className="grid grid-cols-[64px_1fr] md:grid-cols-[60px_1fr] gap-3 md:gap-3 items-start">
+          <div className="flex flex-col items-center text-center md:text-center justify-self-start">
+            <Avatar
+              src={data.avatarUrl ?? undefined}
+              name={`${data.authorName ?? '임원'} 아바타`}
+              size={mode === 'full' ? 'lg' : 'md'}
+              showName={false}
+            />
+            <div className="mt-2">
+              <div className="body-sm font-medium text-grey-900">
+                {data.authorName ?? '임원'}
+              </div>
+              {data.authorTitle && (
+                <div className="body-xs text-grey-500">{data.authorTitle}</div>
+              )}
+            </div>
+          </div>
+
+          <div className="relative bg-white rounded-[5px] shadow-md md:shadow-md drop-shadow-[4px_4px_8px_rgba(0,0,0,0.05)] p-4 md:p-5 before:content-[''] before:absolute before:left-[-8px] before:top-6 before:border-y-[8px] before:border-y-transparent before:border-r-[8px] before:border-r-white">
+            <p className="body-sm text-fixed-grey-900 whitespace-pre-line break-words">
+              {data.message}
+            </p>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/hooks/useAttendance.ts
+++ b/src/hooks/useAttendance.ts
@@ -193,6 +193,7 @@ export function useAttendance(
   const handleClockIn = useCallback(() => {
     if (isPending) return;
 
+    const previous = attendance;
     const nextState: AttendanceViewState = {
       status: 'in',
       clockInAt: new Date().toISOString(),
@@ -207,7 +208,7 @@ export function useAttendance(
       void (async () => {
         const result = await requestClockIn();
         if (!result.ok) {
-          setAttendance(initialAttendanceState);
+          setAttendance(previous);
           const message =
             result.error === 'UNAUTHENTICATED'
               ? '로그인이 필요해요.'
@@ -217,7 +218,7 @@ export function useAttendance(
         }
 
         if (!result.data) {
-          setAttendance(initialAttendanceState);
+          setAttendance(previous);
           showToast('출근 정보가 확인되지 않아요.', 'error');
           return;
         }
@@ -227,11 +228,12 @@ export function useAttendance(
         showToast('출근 완료! 활기찬 갓생 보내세요.', 'success');
       })();
     });
-  }, [isPending, refreshRate, showToast]);
+  }, [attendance, isPending, refreshRate, showToast]);
 
   const handleEarlyLeave = useCallback(() => {
     if (isPending || attendance.status !== 'in') return;
 
+    const previous = attendance;
     const nextState: AttendanceViewState = {
       ...attendance,
       status: 'early',
@@ -243,7 +245,7 @@ export function useAttendance(
       void (async () => {
         const result = await requestEarlyLeave();
         if (!result.ok) {
-          setAttendance(attendance);
+          setAttendance(previous);
           const errorMessage =
             result.error === 'UNAUTHENTICATED'
               ? '로그인이 필요해요.'
@@ -255,7 +257,7 @@ export function useAttendance(
         }
 
         if (!result.data) {
-          setAttendance(attendance);
+          setAttendance(previous);
           showToast('조퇴 정보가 확인되지 않아요.', 'error');
           return;
         }
@@ -270,6 +272,7 @@ export function useAttendance(
     if (isPending || attendance.status === 'none') return;
 
     const nowIso = new Date().toISOString();
+    const previous = attendance;
     const optimistic: AttendanceViewState = {
       ...attendance,
       status: 'out',
@@ -286,7 +289,7 @@ export function useAttendance(
       void (async () => {
         const result = await requestClockOut();
         if (!result.ok) {
-          setAttendance(attendance);
+          setAttendance(previous);
           const errorMessage =
             result.error === 'UNAUTHENTICATED'
               ? '로그인이 필요해요.'
@@ -298,7 +301,7 @@ export function useAttendance(
         }
 
         if (!result.data) {
-          setAttendance(attendance);
+          setAttendance(previous);
           showToast('퇴근 정보가 확인되지 않아요.', 'error');
           return;
         }

--- a/src/hooks/useExecMessage.ts
+++ b/src/hooks/useExecMessage.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { fetchExecMessage } from '@/services/execMessage';
+import type { ExecMessage } from '@/app/_actions/execMessage';
+
+export type ExecMessageLifecycle = 'idle' | 'loading' | 'success' | 'error';
+
+interface UseExecMessageOptions {
+  autoLoad?: boolean;
+}
+
+interface UseExecMessageResult {
+  lifecycle: ExecMessageLifecycle;
+  data: ExecMessage | null;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useExecMessage(
+  options: UseExecMessageOptions = {}
+): UseExecMessageResult {
+  const { autoLoad = true } = options;
+  const [lifecycle, setLifecycle] = useState<ExecMessageLifecycle>('idle');
+  const [data, setData] = useState<ExecMessage | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLifecycle('loading');
+    setError(null);
+
+    const result = await fetchExecMessage();
+    if (result.ok) {
+      setData(result.data);
+      setLifecycle('success');
+    } else {
+      setData(null);
+      setError(result.error);
+      setLifecycle('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!autoLoad) return;
+    void load();
+  }, [autoLoad, load]);
+
+  return {
+    lifecycle,
+    data,
+    error,
+    refresh: load,
+  };
+}

--- a/src/services/execMessage.ts
+++ b/src/services/execMessage.ts
@@ -1,0 +1,21 @@
+import { getCurrentExecMessage } from '@/app/_actions/execMessage';
+
+const DEFAULT_TIMEOUT = 3000;
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs = DEFAULT_TIMEOUT) {
+  return Promise.race<T>([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error('Request timeout')), timeoutMs)
+    ),
+  ]);
+}
+
+export async function fetchExecMessage() {
+  try {
+    return await withTimeout(getCurrentExecMessage());
+  } catch (error) {
+    console.error('[services/execMessage] fetchExecMessage failed', error);
+    return { ok: false as const, error: 'UNKNOWN' };
+  }
+}

--- a/supabase-exec-messages.sql
+++ b/supabase-exec-messages.sql
@@ -1,0 +1,165 @@
+-- ============================================================================
+-- 임원진 한마디 & 명언 시스템 (exec_messages / exec_quotes)
+-- 실행 위치: Supabase SQL Editor
+-- 목적: 홈 위젯과 향후 페이지에서 사용할 운영 공지/명언 데이터 준비
+-- ============================================================================
+
+-- 1) exec_messages 테이블 ----------------------------------------------------
+create table if not exists public.exec_messages (
+  id uuid primary key default gen_random_uuid(),
+  author_user_id uuid references auth.users(id),
+  author_name text,
+  author_title text,
+  avatar_url text,
+  message text not null,
+  lang text,
+  is_active boolean not null default true,
+  start_at timestamptz,
+  end_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create or replace function public.set_exec_message_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end $$;
+
+drop trigger if exists trg_exec_messages_updated_at on public.exec_messages;
+create trigger trg_exec_messages_updated_at
+before update on public.exec_messages
+for each row execute function public.set_exec_message_updated_at();
+
+alter table public.exec_messages enable row level security;
+
+drop policy if exists exec_messages_read on public.exec_messages;
+drop policy if exists exec_messages_write_self on public.exec_messages;
+
+create policy exec_messages_read
+  on public.exec_messages
+  for select
+  to authenticated
+  using (true);
+
+create policy exec_messages_write_self
+  on public.exec_messages
+  for all
+  to authenticated
+  using (coalesce(author_user_id, auth.uid()) = auth.uid())
+  with check (coalesce(author_user_id, auth.uid()) = auth.uid());
+
+-- 2) exec_quotes 테이블 ------------------------------------------------------
+create table if not exists public.exec_quotes (
+  id uuid primary key default gen_random_uuid(),
+  author_code text not null,
+  author_name text not null,
+  author_title text not null,
+  message text not null,
+  lang text not null default 'ko',
+  is_active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create or replace function public.set_exec_quote_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end $$;
+
+drop trigger if exists trg_exec_quotes_updated_at on public.exec_quotes;
+create trigger trg_exec_quotes_updated_at
+before update on public.exec_quotes
+for each row execute function public.set_exec_quote_updated_at();
+
+alter table public.exec_quotes enable row level security;
+
+drop policy if exists exec_quotes_read on public.exec_quotes;
+drop policy if exists exec_quotes_write_self on public.exec_quotes;
+
+create policy exec_quotes_read
+  on public.exec_quotes
+  for select
+  to authenticated
+  using (true);
+
+create policy exec_quotes_write_self
+  on public.exec_quotes
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+-- 3) 뷰 정의 ----------------------------------------------------------------
+-- 최신 공지 1건
+create or replace view public.v_exec_message_current as
+select
+  em.id,
+  coalesce(em.author_name, p.last_name) as author_name,
+  coalesce(em.author_title, p.rank::text) as author_title,
+  coalesce(em.avatar_url, p.avatar_url) as avatar_url,
+  em.message,
+  em.lang,
+  em.created_at
+from public.exec_messages em
+left join public.profiles p on p.id = em.author_user_id
+where em.is_active = true
+  and (em.start_at is null or now() >= em.start_at)
+  and (em.end_at is null or now() < em.end_at)
+order by coalesce(em.start_at, em.created_at) desc, em.created_at desc
+limit 1;
+
+-- 오늘의 명언 1건
+create or replace view public.v_exec_quote_of_today as
+select *
+from public.exec_quotes q
+where q.is_active = true
+order by md5(q.id::text || to_char(now()::date, 'YYYYMMDD')) asc
+limit 1;
+
+-- 공지 우선, 없으면 명언
+create or replace view public.v_exec_message_current_or_quote as
+with current_msg as (
+  select
+    em.id,
+    coalesce(em.author_name, '임원') as author_name,
+    coalesce(em.author_title, '임원진') as author_title,
+    em.avatar_url,
+    em.message,
+    em.lang,
+    em.created_at,
+    true as is_explicit_message
+  from public.v_exec_message_current em
+),
+today_quote as (
+  select
+    q.id,
+    q.author_name,
+    q.author_title,
+    null::text as avatar_url,
+    q.message,
+    q.lang,
+    q.created_at,
+    false as is_explicit_message
+  from public.v_exec_quote_of_today q
+)
+select * from current_msg
+union all
+select * from today_quote
+order by is_explicit_message desc, created_at desc
+limit 1;
+
+comment on view public.v_exec_message_current_or_quote is '임원 공지 우선, 없으면 오늘의 명언을 반환';
+
+-- 4) 시드 데이터 -------------------------------------------------------------
+insert into public.exec_quotes (author_code, author_name, author_title, message)
+values
+('ceo','갓끼','CEO','일찍 일어나는 새는 수업가서 존다. 8시간 이상 숙면🩷'),
+('cto','갓햄','CTO','일찍 일어나는 벌레는 오운완해서 잽싸게 도망간다.'),
+('coo','갓냥','COO','계속 미루는 사람은 하루를 주든 1년을 주든 못 끝냄')
+on conflict (id) do nothing;
+
+-- ============================================================================


### PR DESCRIPTION
## 📋 작업 내용
- ExecMessageView 컴포넌트 구현 (src/components/shared/ExecMessageView.tsx)
- Skeleton, EmptyState, lifecycle('loading'|'error'|'success') 처리 로직 추가
- Avatar, 이름, 직급, SpeechBubble 레이아웃 완성

## 🎯 관련 이슈
Closes #40 

## 📝 변경사항
- 컴포넌트(UI)와 로직(fetch/useExecMessage hook) 명확히 분리
- 후속 개발 시 `ExecMessagePage.tsx`에서 확장 가능 (CRUD 등)
- `v_exec_message_daily` 뷰 연동 준비 완료

## 🧾 향후 계획
- Supabase `exec_quotes` DB 생성 및 CRUD 로직 추가
- admin 계정(CEO/CTO/COO) 전용 Quote Management 페이지 구현
- 임원 데이터 seed (갓끼🐰, 갓햄🐹, 갓냥🐱) 삽입
- `v_exec_message_daily` 뷰로 하루 1개 명언 자동 노출

## 📸 스크린샷
<img width="451" height="237" alt="Screenshot 2025-11-08 at 23 27 32" src="https://github.com/user-attachments/assets/e9740357-4aa5-4d32-a442-78dd29935303" />
