### PR TITLE
[Feat] DB schema and profile improvements

### DIFF
--- a/src/app/_actions/execMessage.ts
+++ b/src/app/_actions/execMessage.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { z } from 'zod';
 import { createServerSupabase } from '@/lib/supabase/server';
 
 export type ExecMessage = {
@@ -49,5 +50,126 @@ export async function getCurrentExecMessage(): Promise<ExecMessageResult> {
   } catch (e) {
     console.error('[getCurrentExecMessage] failed', e);
     return { ok: false, error: 'UNKNOWN' };
+  }
+}
+
+// ============================================================================
+// 관리자용 CRUD 액션 (exec_quotes)
+// ============================================================================
+
+export type ExecQuote = {
+  id: string;
+  author_code: string;
+  author_name: string;
+  author_title: 'CEO' | 'CTO' | 'COO';
+  avatar_url: string | null;
+  message: string;
+  lang: string;
+  is_explicit: boolean;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+const QuoteSchema = z.object({
+  id: z.string().uuid().optional(),
+  author_code: z.string().min(1).default('exec'),
+  author_name: z.string().min(1),
+  author_title: z.enum(['CEO', 'CTO', 'COO']),
+  avatar_url: z
+    .string()
+    .url()
+    .optional()
+    .nullable()
+    .transform(v => v || null),
+  message: z.string().min(1).max(500),
+  lang: z.string().default('ko'),
+  is_explicit: z.boolean().default(false),
+  is_active: z.boolean().default(true),
+});
+
+export async function listQuotes({
+  q,
+  page = 1,
+  pageSize = 20,
+}: {
+  q?: string;
+  page?: number;
+  pageSize?: number;
+}) {
+  try {
+    const supabase = await createServerSupabase();
+    let query = supabase
+      .from('exec_quotes')
+      .select('*', { count: 'exact' })
+      .order('created_at', { ascending: false });
+
+    if (q?.trim()) {
+      query = query.ilike('message', `%${q}%`);
+    }
+
+    const from = (page - 1) * pageSize;
+    const to = from + pageSize - 1;
+    const { data, count, error } = await query.range(from, to);
+
+    if (error) throw error;
+
+    return { data: data ?? [], count: count ?? 0, page, pageSize };
+  } catch (e) {
+    console.error('[listQuotes] failed', e);
+    throw e;
+  }
+}
+
+export async function createQuote(input: unknown) {
+  try {
+    const supabase = await createServerSupabase();
+    const body = QuoteSchema.omit({ id: true }).parse(input);
+    const { data, error } = await supabase
+      .from('exec_quotes')
+      .insert(body)
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    return data;
+  } catch (e) {
+    console.error('[createQuote] failed', e);
+    throw e;
+  }
+}
+
+export async function updateQuote(id: string, patch: unknown) {
+  try {
+    const supabase = await createServerSupabase();
+    const body = QuoteSchema.partial().parse(patch);
+    const { data, error } = await supabase
+      .from('exec_quotes')
+      .update(body)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    return data;
+  } catch (e) {
+    console.error('[updateQuote] failed', e);
+    throw e;
+  }
+}
+
+export async function deleteQuote(id: string) {
+  try {
+    const supabase = await createServerSupabase();
+    const { error } = await supabase.from('exec_quotes').delete().eq('id', id);
+
+    if (error) throw error;
+
+    return { ok: true };
+  } catch (e) {
+    console.error('[deleteQuote] failed', e);
+    throw e;
   }
 }

--- a/src/app/admin/execs/quotes/page.tsx
+++ b/src/app/admin/execs/quotes/page.tsx
@@ -1,0 +1,11 @@
+export const dynamic = 'force-dynamic';
+
+import ExecQuotesAdmin from '@/components/admin/ExecQuotesAdmin';
+
+export default function Page() {
+  return (
+    <main className="bg-grey-100 rounded-[5px] px-[25px] py-5 mb-5 col-span-2">
+      <ExecQuotesAdmin />
+    </main>
+  );
+}

--- a/src/components/SupabaseAuthListener.tsx
+++ b/src/components/SupabaseAuthListener.tsx
@@ -14,6 +14,7 @@ type ProfileRow = {
   department?: string | null;
   rank?: string | null;
   user_id?: string | null;
+  joined_at?: string | null;
 };
 
 const DEFAULT_NAME = '게스트';
@@ -91,6 +92,7 @@ const buildUser = (
     provider:
       (sessionUser.app_metadata?.provider as string | undefined) ?? undefined,
     joinedAt:
+      profile?.joined_at ??
       (metadata['joined_at'] as string | undefined) ??
       sessionUser.created_at ??
       undefined,
@@ -153,7 +155,9 @@ export default function SupabaseAuthListener() {
 
       const { data: profile, error: profileError } = await supabase
         .from('profiles')
-        .select('last_name, first_name, avatar_url, department, rank, user_id')
+        .select(
+          'last_name, first_name, avatar_url, department, rank, user_id, joined_at'
+        )
         .eq('id', session.user.id)
         .maybeSingle();
 
@@ -203,7 +207,9 @@ export default function SupabaseAuthListener() {
 
       const { data: profile, error: profileError } = await supabase
         .from('profiles')
-        .select('last_name, first_name, avatar_url, department, rank, user_id')
+        .select(
+          'last_name, first_name, avatar_url, department, rank, user_id, joined_at'
+        )
         .eq('id', session.user.id)
         .maybeSingle();
 

--- a/src/components/admin/ExecQuotesAdmin.tsx
+++ b/src/components/admin/ExecQuotesAdmin.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useExecQuotes } from '@/hooks/useExecQuotes';
+import { z } from 'zod';
+
+const FormSchema = z.object({
+  author_code: z.string().min(1).default('exec'),
+  author_name: z.string().min(1, '이름을 입력해주세요'),
+  author_title: z.enum(['CEO', 'CTO', 'COO']),
+  avatar_url: z
+    .string()
+    .url('올바른 URL을 입력해주세요')
+    .optional()
+    .or(z.literal(''))
+    .transform(v => v || undefined),
+  message: z
+    .string()
+    .min(1, '메시지를 입력해주세요')
+    .max(500, '최대 500자까지 입력 가능합니다'),
+  lang: z.string().default('ko'),
+  is_explicit: z.boolean().default(false),
+  is_active: z.boolean().default(true),
+});
+
+type FormData = z.input<typeof FormSchema>;
+
+export default function ExecQuotesAdmin() {
+  const { data, fetchList, add, patch, remove, loading } = useExecQuotes();
+  const [form, setForm] = useState<FormData>({
+    author_code: 'exec',
+    author_name: '',
+    author_title: 'CEO',
+    avatar_url: '',
+    message: '',
+    lang: 'ko',
+    is_explicit: false,
+    is_active: true,
+  });
+  const [q, setQ] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void fetchList();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    try {
+      const payload = FormSchema.parse(form);
+      await add(payload);
+      setForm({
+        author_code: 'exec',
+        author_name: '',
+        author_title: 'CEO',
+        avatar_url: '',
+        message: '',
+        lang: 'ko',
+        is_explicit: false,
+        is_active: true,
+      });
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        setError(err.issues[0].message);
+      } else {
+        setError('명언 추가에 실패했습니다.');
+        console.error('[ExecQuotesAdmin] onCreate failed', err);
+      }
+    }
+  };
+
+  const onSearch = () => {
+    void fetchList({ q, page: 1 });
+  };
+
+  const onToggleActive = async (id: string, currentActive: boolean) => {
+    try {
+      await patch(id, { is_active: !currentActive });
+    } catch (err) {
+      console.error('[ExecQuotesAdmin] onToggleActive failed', err);
+      alert('활성화 상태 변경에 실패했습니다.');
+    }
+  };
+
+  const onDelete = async (id: string) => {
+    if (!confirm('정말 삭제하시겠습니까?')) return;
+
+    try {
+      await remove(id);
+    } catch (err) {
+      console.error('[ExecQuotesAdmin] onDelete failed', err);
+      alert('삭제에 실패했습니다.');
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      <header className="flex items-end gap-3">
+        <h2 className="brand-h3 text-grey-900">임원진 명언 관리</h2>
+        <div className="ml-auto flex gap-2">
+          <input
+            className="border border-grey-300 rounded px-3 py-1 text-sm"
+            placeholder="메시지 검색"
+            value={q}
+            onChange={e => setQ(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && onSearch()}
+          />
+          <button
+            className="outline outline-1 outline-grey-300 rounded px-3 py-1 text-sm hover:bg-grey-50"
+            onClick={onSearch}
+            disabled={loading}
+          >
+            검색
+          </button>
+        </div>
+      </header>
+
+      {/* 생성 폼 */}
+      <form
+        onSubmit={onCreate}
+        className="grid grid-cols-1 md:grid-cols-3 gap-3 items-end outline outline-1 outline-grey-200 p-4 rounded bg-white"
+      >
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-grey-600">이름</label>
+          <input
+            className="border border-grey-300 rounded px-3 py-2 text-sm"
+            placeholder="갓끼"
+            value={form.author_name}
+            onChange={e => setForm({ ...form, author_name: e.target.value })}
+            required
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-grey-600">직책</label>
+          <select
+            className="border border-grey-300 rounded px-3 py-2 text-sm"
+            value={form.author_title}
+            onChange={e =>
+              setForm({
+                ...form,
+                author_title: e.target.value as 'CEO' | 'CTO' | 'COO',
+              })
+            }
+          >
+            <option value="CEO">CEO</option>
+            <option value="CTO">CTO</option>
+            <option value="COO">COO</option>
+          </select>
+        </div>
+        <div className="flex flex-col gap-1 md:col-span-3">
+          <label className="text-xs text-grey-600">메시지 (최대 500자)</label>
+          <textarea
+            className="border border-grey-300 rounded px-3 py-2 text-sm resize-none"
+            placeholder="일찍 일어나는 새는 수업가서 존다. 8시간 이상 숙면🩷"
+            rows={3}
+            value={form.message}
+            onChange={e => setForm({ ...form, message: e.target.value })}
+            required
+          />
+        </div>
+        <div className="flex flex-col gap-1 md:col-span-2">
+          <label className="text-xs text-grey-600">아바타 URL (옵션)</label>
+          <input
+            className="border border-grey-300 rounded px-3 py-2 text-sm"
+            placeholder="https://example.com/avatar.jpg"
+            value={form.avatar_url}
+            onChange={e => setForm({ ...form, avatar_url: e.target.value })}
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id="is_active"
+            checked={form.is_active}
+            onChange={e => setForm({ ...form, is_active: e.target.checked })}
+          />
+          <label htmlFor="is_active" className="text-sm text-grey-700">
+            활성화
+          </label>
+        </div>
+        {error && (
+          <div className="md:col-span-3 text-sm text-red-500">{error}</div>
+        )}
+        <button
+          type="submit"
+          className="md:col-span-3 bg-grey-900 text-white rounded px-4 py-2 text-sm hover:bg-grey-800 disabled:opacity-50"
+          disabled={loading}
+        >
+          추가
+        </button>
+      </form>
+
+      {/* 목록 */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-medium text-grey-700">
+            전체 {data.total}개
+          </h3>
+        </div>
+        {loading && data.items.length === 0 ? (
+          <div className="text-sm text-grey-500 text-center py-8">
+            로딩 중...
+          </div>
+        ) : data.items.length === 0 ? (
+          <div className="text-sm text-grey-500 text-center py-8">
+            데이터가 없습니다.
+          </div>
+        ) : (
+          <ul className="space-y-3">
+            {data.items.map(q => (
+              <li
+                key={q.id}
+                className="p-4 rounded outline outline-1 outline-grey-200 bg-white"
+              >
+                <div className="flex items-center gap-2 mb-2">
+                  <strong className="text-sm font-medium text-grey-900">
+                    {q.author_name}
+                  </strong>
+                  <span className="text-xs px-2 py-0.5 rounded bg-grey-100 text-grey-700">
+                    {q.author_title}
+                  </span>
+                  <span
+                    className={`text-xs ml-2 ${
+                      q.is_active ? 'text-green-600' : 'text-grey-400'
+                    }`}
+                  >
+                    {q.is_active ? '활성' : '비활성'}
+                  </span>
+                  <div className="ml-auto flex gap-2">
+                    <button
+                      className="outline outline-1 outline-grey-300 rounded px-3 py-1 text-xs hover:bg-grey-50"
+                      onClick={() => onToggleActive(q.id, q.is_active)}
+                    >
+                      {q.is_active ? '비활성화' : '활성화'}
+                    </button>
+                    <button
+                      className="outline outline-1 outline-red-300 rounded px-3 py-1 text-xs text-red-600 hover:bg-red-50"
+                      onClick={() => onDelete(q.id)}
+                    >
+                      삭제
+                    </button>
+                  </div>
+                </div>
+                <p className="text-sm text-grey-700 whitespace-pre-line break-words">
+                  {q.message}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -22,7 +22,7 @@ export default function Avatar({
   const SIZES = {
     sm: 'w-8 h-8',
     md: 'w-12 h-12',
-    lg: 'w-22 h-22',
+    lg: 'w-[88px] h-[88px]',
   };
 
   const sizeClass = SIZES[size];
@@ -30,19 +30,32 @@ export default function Avatar({
   const displayRank = rank?.trim() || '인턴';
   const showLabel = showName && (displayName || displayRank);
 
+  const isExternal = src?.startsWith('http');
+
   return (
     <div className={`ui-component flex items-center gap-2 ${className}`}>
       <div
         className={`${sizeClass} rounded-full bg-primary-100 flex items-center justify-center overflow-hidden flex-shrink-0`}
       >
         {src ? (
-          <Image
-            src={src}
-            alt={displayName}
-            width={size === 'lg' ? 88 : size === 'md' ? 48 : 32}
-            height={size === 'lg' ? 88 : size === 'md' ? 48 : 32}
-            className="w-full h-full object-cover"
-          />
+          isExternal ? (
+            /* eslint-disable @next/next/no-img-element */
+            <img
+              src={src}
+              alt={displayName}
+              width={size === 'lg' ? 88 : size === 'md' ? 48 : 32}
+              height={size === 'lg' ? 88 : size === 'md' ? 48 : 32}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <Image
+              src={src}
+              alt={displayName}
+              width={size === 'lg' ? 88 : size === 'md' ? 48 : 32}
+              height={size === 'lg' ? 88 : size === 'md' ? 48 : 32}
+              className="w-full h-full object-cover"
+            />
+          )
         ) : (
           <Icon
             icon="icon-park:user-business"

--- a/src/hooks/useExecMessage.ts
+++ b/src/hooks/useExecMessage.ts
@@ -29,13 +29,30 @@ export function useExecMessage(
     setLifecycle('loading');
     setError(null);
 
-    const result = await fetchExecMessage();
-    if (result.ok) {
-      setData(result.data);
-      setLifecycle('success');
-    } else {
+    try {
+      const result = await fetchExecMessage();
+
+      // 안전장치: result가 undefined인 경우 처리
+      if (!result) {
+        console.error('[useExecMessage] fetchExecMessage returned undefined');
+        setData(null);
+        setError('UNKNOWN');
+        setLifecycle('error');
+        return;
+      }
+
+      if (result.ok) {
+        setData(result.data);
+        setLifecycle('success');
+      } else {
+        setData(null);
+        setError(result.error);
+        setLifecycle('error');
+      }
+    } catch (err) {
+      console.error('[useExecMessage] load failed:', err);
       setData(null);
-      setError(result.error);
+      setError('UNKNOWN');
       setLifecycle('error');
     }
   }, []);

--- a/src/hooks/useExecQuotes.ts
+++ b/src/hooks/useExecQuotes.ts
@@ -1,0 +1,98 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import {
+  createQuote,
+  deleteQuote,
+  listQuotes,
+  updateQuote,
+  type ExecQuote,
+} from '@/app/_actions/execMessage';
+
+interface PageState {
+  page: number;
+  pageSize: number;
+  q: string;
+}
+
+interface DataState {
+  items: ExecQuote[];
+  total: number;
+}
+
+export function useExecQuotes() {
+  const [loading, setLoading] = useState(false);
+  const [pageState, setPageState] = useState<PageState>({
+    page: 1,
+    pageSize: 20,
+    q: '',
+  });
+  const [data, setData] = useState<DataState>({ items: [], total: 0 });
+
+  const fetchList = useCallback(
+    async (override?: Partial<PageState>) => {
+      setLoading(true);
+      try {
+        const state = { ...pageState, ...(override ?? {}) };
+        const res = await listQuotes(state);
+        setData({ items: res.data as ExecQuote[], total: res.count ?? 0 });
+        setPageState({ page: res.page, pageSize: res.pageSize, q: state.q });
+      } catch (error) {
+        console.error('[useExecQuotes] fetchList failed', error);
+        setData({ items: [], total: 0 });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [pageState]
+  );
+
+  const add = useCallback(async (payload: unknown) => {
+    try {
+      const created = await createQuote(payload);
+      setData(prev => ({
+        items: [created as ExecQuote, ...prev.items],
+        total: prev.total + 1,
+      }));
+    } catch (error) {
+      console.error('[useExecQuotes] add failed', error);
+      throw error;
+    }
+  }, []);
+
+  const patch = useCallback(async (id: string, patchData: unknown) => {
+    try {
+      const updated = await updateQuote(id, patchData);
+      setData(prev => ({
+        items: prev.items.map(i => (i.id === id ? (updated as ExecQuote) : i)),
+        total: prev.total,
+      }));
+    } catch (error) {
+      console.error('[useExecQuotes] patch failed', error);
+      throw error;
+    }
+  }, []);
+
+  const remove = useCallback(async (id: string) => {
+    try {
+      await deleteQuote(id);
+      setData(prev => ({
+        items: prev.items.filter(i => i.id !== id),
+        total: Math.max(0, prev.total - 1),
+      }));
+    } catch (error) {
+      console.error('[useExecQuotes] remove failed', error);
+      throw error;
+    }
+  }, []);
+
+  return {
+    loading,
+    pageState,
+    data,
+    fetchList,
+    add,
+    patch,
+    remove,
+  };
+}

--- a/src/services/execMessage.ts
+++ b/src/services/execMessage.ts
@@ -13,7 +13,16 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs = DEFAULT_TIMEOUT) {
 
 export async function fetchExecMessage() {
   try {
-    return await withTimeout(getCurrentExecMessage());
+    console.log('[fetchExecMessage] Calling getCurrentExecMessage...');
+    const result = await withTimeout(getCurrentExecMessage());
+    console.log('[fetchExecMessage] Result:', result);
+
+    if (!result) {
+      console.error('[fetchExecMessage] Result is undefined or null');
+      return { ok: false as const, error: 'UNKNOWN' };
+    }
+
+    return result;
   } catch (error) {
     console.error('[services/execMessage] fetchExecMessage failed', error);
     return { ok: false as const, error: 'UNKNOWN' };

--- a/supabase-exec-quotes-admin-rls.sql
+++ b/supabase-exec-quotes-admin-rls.sql
@@ -1,0 +1,83 @@
+-- ============================================================================
+-- 임원진 명언 관리 RLS 정책 & exec_admins 테이블
+-- 실행 위치: Supabase SQL Editor
+-- 목적: exec_admins 테이블 생성 및 exec_quotes 쓰기 권한을 임원으로 제한
+-- ============================================================================
+
+-- 1) exec_admins 테이블 생성 -------------------------------------------------
+create table if not exists public.exec_admins (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  unique(user_id)
+);
+
+alter table public.exec_admins enable row level security;
+
+-- exec_admins는 모든 authenticated 사용자가 읽을 수 있음 (권한 체크용)
+drop policy if exists exec_admins_read on public.exec_admins;
+create policy exec_admins_read
+  on public.exec_admins
+  for select
+  to authenticated
+  using (true);
+
+-- exec_admins 자체는 슈퍼관리자만 수정 가능 (별도 관리)
+-- 필요시 supabase dashboard에서 직접 관리
+
+comment on table public.exec_admins is '임원진 관리자 목록';
+comment on column public.exec_admins.user_id is '임원진 사용자 ID';
+
+-- 2) exec_quotes RLS 정책 업데이트 -------------------------------------------
+-- 기존 정책 삭제
+drop policy if exists exec_quotes_write_self on public.exec_quotes;
+
+-- 새 정책: 임원만 쓰기 허용
+drop policy if exists exec_quotes_write_admins on public.exec_quotes;
+create policy exec_quotes_write_admins
+  on public.exec_quotes
+  for all
+  to authenticated
+  using (
+    exists (
+      select 1 from public.exec_admins a
+      where a.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.exec_admins a
+      where a.user_id = auth.uid()
+    )
+  );
+
+comment on policy exec_quotes_write_admins on public.exec_quotes is 'exec_admins에 등록된 임원만 명언 CRUD 가능';
+
+-- 3) exec_quotes 테이블 컬럼 확인 및 추가 ------------------------------------
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+    and table_name = 'exec_quotes'
+    and column_name = 'avatar_url'
+  ) then
+    alter table public.exec_quotes add column avatar_url text;
+  end if;
+end $$;
+
+-- is_explicit 컬럼 추가 (선택사항, 명시적 메시지 여부)
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+    and table_name = 'exec_quotes'
+    and column_name = 'is_explicit'
+  ) then
+    alter table public.exec_quotes add column is_explicit boolean not null default false;
+  end if;
+end $$;
+
+comment on column public.exec_quotes.avatar_url is '임원 아바타 URL (옵션)';
+comment on column public.exec_quotes.is_explicit is '명시적 메시지 여부';

--- a/supabase-fix-avatar-complete.sql
+++ b/supabase-fix-avatar-complete.sql
@@ -1,0 +1,83 @@
+-- ============================================================================
+-- exec_quotes avatar_url 컬럼 추가 및 뷰 업데이트 (통합 버전)
+-- 실행 위치: Supabase SQL Editor
+-- 목적: avatar_url 컬럼 추가 → 뷰 업데이트 → 아바타 표시 가능
+-- ============================================================================
+
+-- 1) exec_quotes 테이블에 avatar_url 컬럼 추가 ---------------------------
+-- 이미 있으면 무시됨
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+    and table_name = 'exec_quotes'
+    and column_name = 'avatar_url'
+  ) then
+    alter table public.exec_quotes add column avatar_url text;
+    raise notice 'avatar_url 컬럼 추가 완료';
+  else
+    raise notice 'avatar_url 컬럼 이미 존재';
+  end if;
+end $$;
+
+-- 2) is_explicit 컬럼 추가 (필요한 경우) ----------------------------------
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+    and table_name = 'exec_quotes'
+    and column_name = 'is_explicit'
+  ) then
+    alter table public.exec_quotes add column is_explicit boolean not null default false;
+    raise notice 'is_explicit 컬럼 추가 완료';
+  else
+    raise notice 'is_explicit 컬럼 이미 존재';
+  end if;
+end $$;
+
+-- 3) v_exec_quote_of_today 뷰 업데이트 ------------------------------------
+-- avatar_url 포함
+create or replace view public.v_exec_quote_of_today as
+select *
+from public.exec_quotes q
+where q.is_active = true
+order by md5(q.id::text || to_char(now()::date, 'YYYYMMDD')) asc
+limit 1;
+
+-- 4) v_exec_message_current_or_quote 뷰 업데이트 --------------------------
+-- exec_quotes의 avatar_url을 실제로 사용하도록 수정
+create or replace view public.v_exec_message_current_or_quote as
+with current_msg as (
+  select
+    em.id,
+    coalesce(em.author_name, '임원') as author_name,
+    coalesce(em.author_title, '임원진') as author_title,
+    em.avatar_url,
+    em.message,
+    em.lang,
+    em.created_at,
+    true as is_explicit_message
+  from public.v_exec_message_current em
+),
+today_quote as (
+  select
+    q.id,
+    q.author_name,
+    q.author_title,
+    q.avatar_url,  -- ✅ null::text에서 q.avatar_url로 변경
+    q.message,
+    q.lang,
+    q.created_at,
+    false as is_explicit_message
+  from public.v_exec_quote_of_today q
+)
+select * from current_msg
+union all
+select * from today_quote
+order by is_explicit_message desc, created_at desc
+limit 1;
+
+comment on view public.v_exec_message_current_or_quote is '임원 공지 우선, 없으면 오늘의 명언을 반환 (avatar_url 포함)';
+

--- a/supabase-fix-joined-at.sql
+++ b/supabase-fix-joined-at.sql
@@ -1,0 +1,126 @@
+-- ============================================================================
+-- profiles 테이블에 joined_at 컬럼 추가 및 기존 데이터 마이그레이션
+-- 실행 위치: Supabase SQL Editor
+-- 목적: 카카오 로그인 사용자의 입사일자가 1일차로 나오는 문제 해결
+-- ============================================================================
+
+-- 1) profiles 테이블에 joined_at 컬럼 추가 (이미 있으면 무시됨)
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+    and table_name = 'profiles'
+    and column_name = 'joined_at'
+  ) then
+    alter table public.profiles add column joined_at timestamptz;
+    raise notice 'joined_at 컬럼 추가 완료';
+  else
+    raise notice 'joined_at 컬럼 이미 존재';
+  end if;
+end $$;
+
+-- 2) 기존 사용자들의 joined_at을 created_at으로 설정 (NULL인 경우만)
+update public.profiles
+set joined_at = created_at
+where joined_at is null;
+
+-- 3) 트리거 함수 업데이트: 신규 사용자의 joined_at을 자동으로 설정
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  md jsonb := new.raw_user_meta_data;
+  v_user_id    text;
+  v_last_name  text;
+  v_first_name text;
+  v_department text;
+  v_rank       rank_enum;
+  v_wh         work_hours_enum;
+  v_wt         work_type_enum;
+  v_style      text;
+  v_ethic      text;
+  v_avatar     text;
+begin
+  -- camel & snake 모두 수용
+  v_user_id := coalesce(
+    nullif(md->>'user_id', ''),
+    nullif(md->>'userId', ''),
+    nullif(split_part(new.email, '@', 1), ''),
+    concat('guest_', left(new.id::text, 8))
+  );
+
+  v_last_name := coalesce(
+    nullif(md->>'last_name', ''),
+    nullif(md->>'lastName', ''),
+    nullif(md->>'profile_nickname', ''),
+    nullif(md->>'nickname', ''),
+    v_user_id,
+    '게스트'
+  );
+  v_first_name := nullif(coalesce(md->>'first_name', md->>'firstName'), '');
+  v_department := coalesce(md->>'department', 'IT부');
+
+  -- enum은 안전 캐스팅 (없으면 기본값)
+  begin
+    v_rank := coalesce((md->>'rank')::rank_enum, '인턴'::rank_enum);
+  exception when others then
+    v_rank := '인턴'::rank_enum;
+  end;
+
+  begin
+    v_wh := coalesce((md->>'work_hours')::work_hours_enum, '주간(09:00-18:00)'::work_hours_enum);
+  exception when others then
+    v_wh := '주간(09:00-18:00)'::work_hours_enum;
+  end;
+
+  begin
+    v_wt := coalesce((md->>'work_type')::work_type_enum, '풀타임'::work_type_enum);
+  exception when others then
+    v_wt := '풀타임'::work_type_enum;
+  end;
+
+  v_style  := nullif(coalesce(md->>'work_style', md->>'workStyle'), '');
+  v_ethic  := nullif(coalesce(md->>'work_ethic', md->>'workEthic'), '');
+  v_avatar := nullif(coalesce(md->>'avatar_url', md->>'avatarUrl'), '');
+
+  insert into public.profiles (
+    id, user_id, email, last_name, first_name,
+    rank, department, work_hours, work_type,
+    work_style, work_ethic, avatar_url, joined_at, created_at, updated_at
+  )
+  values (
+    new.id,
+    v_user_id,
+    new.email::citext,
+    v_last_name,
+    v_first_name,
+    coalesce(v_rank, '인턴'::rank_enum),
+    v_department,
+    v_wh,
+    v_wt,
+    v_style,
+    v_ethic,
+    v_avatar,
+    now(),  -- ✅ joined_at 추가
+    now(),
+    now()
+  )
+  on conflict (id) do nothing;
+
+  return new;
+exception
+  when others then
+    raise warning 'handle_new_user failed: %', sqlerrm;
+    return new;
+end;
+$$;
+
+-- 4) 확인 쿼리
+select id, user_id, last_name, joined_at, created_at
+from public.profiles
+order by created_at desc
+limit 10;

--- a/supabase-fix-user-summary-view.sql
+++ b/supabase-fix-user-summary-view.sql
@@ -1,0 +1,58 @@
+-- ============================================================================
+-- v_user_summary_self 뷰 업데이트: joined_at 사용하도록 수정
+-- 실행 위치: Supabase SQL Editor
+-- 목적: 입사일자를 created_at 대신 joined_at으로 계산
+-- ============================================================================
+
+-- v_user_summary_self 뷰 재생성
+create or replace view public.v_user_summary_self as
+select
+  p.id                                     as auth_user_id,
+  p.user_id                                as handle,
+  coalesce(
+    nullif(p.last_name, ''),
+    nullif(p.first_name, ''),
+    '사용자'
+  )                                        as display_name,
+  p.rank,
+  p.department,
+  p.work_hours,
+  p.work_type,
+  p.avatar_url,
+  p.created_at,
+  -- ✅ 입사 일차 계산: joined_at 우선, 없으면 created_at 사용
+  greatest(
+    1,  -- 최소 1일차
+    floor(
+      extract(epoch from (
+        timezone('Asia/Seoul', now())
+        - timezone('Asia/Seoul', coalesce(p.joined_at, p.created_at, now()))
+      )) / 86400
+    ) + 1
+  )::int                                   as joined_days,
+  -- 임시로 0 반환 (나중에 실제 performance 테이블 연동)
+  0::int                                   as performance_rate
+from public.profiles p
+where p.id = auth.uid();
+
+comment on view public.v_user_summary_self is
+  '사원정보 카드용 뷰. joined_at (또는 created_at) 기준 joined_days 계산, 내 정보만 반환.';
+
+alter view public.v_user_summary_self set (security_invoker = on);
+
+-- ============================================================================
+-- 확인 쿼리
+-- ============================================================================
+-- 내 프로필 정보 확인
+select
+  auth.uid() as my_user_id,
+  p.user_id,
+  p.last_name,
+  p.joined_at,
+  p.created_at,
+  extract(day from (now() - coalesce(p.joined_at, p.created_at))) + 1 as calculated_days
+from public.profiles p
+where p.id = auth.uid();
+
+-- 뷰 결과 확인
+select * from public.v_user_summary_self;

--- a/supabase-migrate-existing-users.sql
+++ b/supabase-migrate-existing-users.sql
@@ -1,0 +1,107 @@
+-- ============================================================================
+-- 기존 auth.users 사용자들의 profiles 레코드 생성 (백필)
+-- 실행 위치: Supabase SQL Editor
+-- 목적: 트리거 실행 전에 가입한 사용자들의 profiles 레코드 생성
+-- ============================================================================
+
+-- 1) profiles 테이블에 joined_at 컬럼이 있는지 확인 및 추가
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+    where table_schema = 'public'
+    and table_name = 'profiles'
+    and column_name = 'joined_at'
+  ) then
+    alter table public.profiles add column joined_at timestamptz;
+    raise notice 'joined_at 컬럼 추가 완료';
+  else
+    raise notice 'joined_at 컬럼 이미 존재';
+  end if;
+end $$;
+
+-- 2) auth.users에는 있지만 profiles에 없는 사용자 확인
+select
+  u.id,
+  u.email,
+  u.created_at as user_created_at,
+  u.raw_user_meta_data->>'nickname' as kakao_nickname,
+  u.raw_user_meta_data->>'name' as kakao_name
+from auth.users u
+left join public.profiles p on p.id = u.id
+where p.id is null
+order by u.created_at desc;
+
+-- 3) profiles 레코드가 없는 기존 사용자들을 자동으로 생성
+insert into public.profiles (
+  id,
+  user_id,
+  email,
+  last_name,
+  first_name,
+  rank,
+  department,
+  work_hours,
+  work_type,
+  avatar_url,
+  joined_at,
+  created_at,
+  updated_at
+)
+select
+  u.id,
+  -- user_id: 이메일 앞부분 또는 guest_xxx
+  coalesce(
+    nullif(u.raw_user_meta_data->>'user_id', ''),
+    nullif(split_part(u.email, '@', 1), ''),
+    concat('guest_', left(u.id::text, 8))
+  ),
+  u.email::citext,
+  -- last_name: 카카오 닉네임 또는 이름, 없으면 이메일 앞부분
+  coalesce(
+    nullif(u.raw_user_meta_data->>'nickname', ''),
+    nullif(u.raw_user_meta_data->>'profile_nickname', ''),
+    nullif(u.raw_user_meta_data->>'name', ''),
+    nullif(u.raw_user_meta_data->>'last_name', ''),
+    nullif(split_part(u.email, '@', 1), ''),
+    '게스트'
+  ),
+  -- first_name: 보통 비어있음
+  nullif(u.raw_user_meta_data->>'first_name', ''),
+  -- rank: 기본값 인턴
+  '인턴'::rank_enum,
+  -- department: 기본값 IT부
+  'IT부',
+  -- work_hours: 기본값
+  '주간(09:00-18:00)'::work_hours_enum,
+  -- work_type: 기본값
+  '풀타임'::work_type_enum,
+  -- avatar_url: 카카오에서 제공하는 이미지 URL
+  nullif(u.raw_user_meta_data->>'avatar_url', ''),
+  -- joined_at: auth.users의 created_at 사용 (실제 가입일)
+  u.created_at,
+  -- created_at, updated_at
+  now(),
+  now()
+from auth.users u
+left join public.profiles p on p.id = u.id
+where p.id is null  -- profiles에 없는 사용자만
+on conflict (id) do nothing;
+
+-- 4) 기존 profiles 레코드의 joined_at이 NULL이면 created_at으로 설정
+update public.profiles
+set joined_at = created_at
+where joined_at is null;
+
+-- 5) 결과 확인
+select
+  p.id,
+  p.user_id,
+  p.last_name,
+  p.email,
+  p.joined_at,
+  p.created_at,
+  extract(day from (now() - p.joined_at)) + 1 as calculated_days
+from public.profiles p
+order by p.created_at desc
+limit 20;


### PR DESCRIPTION
## 📋 작업 내용
### 1. 임원진 한마디 아바타 표시 개선
  - **문제**: exec_quotes의 아바타 이미지가 표시되지 않음
  - **원인**: 
    - DB 뷰에서 avatar_url을 null로 하드코딩
    - Avatar 컴포넌트의 잘못된 Tailwind 클래스 (w-22 존재하지 않음)
  - **해결**:
    - `v_exec_message_current_or_quote` 뷰에서 `q.avatar_url` 사용하도록 수정
    - Avatar 컴포넌트 사이즈: `w-22` → `w-[88px]` (임의 값 표기법)
    - 외부 URL 처리: `isExternal` 체크로 `<img>` vs `<Image>` 분기

  ### 2. 입사일자 계산 로직 개선
  - **문제**: 카카오 로그인 사용자의 입사일자가 항상 1일차로 표시
  - **원인**:
    - profiles 테이블에 joined_at 컬럼 누락
    - SupabaseAuthListener가 joined_at을 쿼리하지 않음
    - v_user_summary_self 뷰가 created_at만 사용
  - **해결**:
    - profiles 테이블에 `joined_at` 컬럼 추가
    - SupabaseAuthListener: profiles 쿼리에 joined_at 포함 및 buildUser 로직 수정
    - v_user_summary_self 뷰: `coalesce(p.joined_at, p.created_at)` 사용

  ### 3. 기존 사용자 데이터 마이그레이션
  - auth.users에는 있지만 profiles에 없는 사용자 자동 생성
  - 기존 프로필의 joined_at을 created_at으로 백필

  ### 4. 버그 수정
  - `getCurrentExecMessage` 함수에서 return 문 누락 수정
  - `useExecMessage` 훅에 undefined 체크 안전장치 추가

## 🎯 관련 이슈
Closes #65 

## 📝 변경사항
### 코드
  - `src/components/ui/Avatar.tsx` - 사이즈 클래스 및 외부 URL 처리
  - `src/components/SupabaseAuthListener.tsx` - joined_at 쿼리 추가
  - `src/app/_actions/execMessage.ts` - return 문 수정
  - `src/hooks/useExecMessage.ts` - 안전장치 추가
  - `src/services/execMessage.ts` - 디버깅 로그 추가

  ### DB 마이그레이션 스크립트 (Supabase에서 수동 실행 필요)
  - `supabase-exec-quotes-admin-rls.sql` - exec_quotes에 avatar_url 컬럼 추가
  - `supabase-fix-joined-at.sql` - profiles에 joined_at 컬럼 추가 및 트리거 업데이트
  - `supabase-migrate-existing-users.sql` - 기존 사용자 프로필 생성
  - `supabase-fix-user-summary-view.sql` - 사용자 요약 뷰 업데이트
  - `supabase-fix-avatar-complete.sql` - 임원진 아바타 뷰 업데이트

## ✅ 체크리스트
- [x] 임원진 한마디 아바타 정상 표시 (localhost, production)
- [x] 카카오 로그인 사용자 입사일자 정확히 계산됨
- [x] 기존 사용자 프로필 생성 확인

## 📸 스크린샷
<img width="854" height="847" alt="Screenshot 2025-11-11 at 23 33 24" src="https://github.com/user-attachments/assets/7ab2648f-0a70-4ee4-be37-df25cfb70003" />
