### PR TITLE
[Feat] integrate rolling 7-day Today rank data

### DIFF
--- a/src/app/_actions/todayRank.ts
+++ b/src/app/_actions/todayRank.ts
@@ -1,0 +1,61 @@
+'use server';
+
+import { admin } from '@/lib/supabase/admin';
+import type { TodayRankUser } from '@/types/todayRank';
+
+export type TodayRankOptions = {
+  periodDays?: number;
+  limit?: number;
+};
+
+type TodayRankRow = {
+  user_id: string;
+  display_name: string | null;
+  department_name: string | null;
+  performance_rate: number | null;
+  attendance_rate: number | null;
+};
+
+const clampPercentage = (value?: number | null) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return 0;
+  return Math.min(Math.max(value, 0), 100);
+};
+
+export async function getTodayRanks(
+  options?: TodayRankOptions
+): Promise<TodayRankUser[]> {
+  const periodDays = options?.periodDays ?? 7;
+  const limit = options?.limit ?? 3;
+
+  try {
+    const { data, error } = await admin.rpc('get_today_ranks', {
+      period_days: periodDays,
+      limit_count: limit,
+    });
+
+    if (error) {
+      console.error('[getTodayRanks] RPC failed', error);
+      return [];
+    }
+
+    const rows = (data ?? []) as TodayRankRow[];
+
+    const ranks: TodayRankUser[] = rows
+      .filter((row: TodayRankRow) => !!row.user_id)
+      .map(
+        (row: TodayRankRow): TodayRankUser => ({
+          userId: row.user_id,
+          displayName: (row.display_name ?? '익명 사원').trim() || '익명 사원',
+          departmentName:
+            (row.department_name ?? '부서 미정').trim() || '부서 미정',
+          performanceRate: clampPercentage(row.performance_rate),
+          attendanceRate: clampPercentage(row.attendance_rate),
+        })
+      );
+
+    return ranks;
+  } catch (error) {
+    console.error('[getTodayRanks] unexpected error', error);
+    return [];
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,8 @@ import { userAtom } from '@/store/atoms';
 import UserInfoCard from '@/components/home/UserInfoCard';
 import ExecMessageCard from '@/components/home/ExecMessageCard';
 import PerformanceWidget from '@/components/home/PerformanceWidget';
+import { TodayRankWidget } from '@/components/home/TodayRankWidget';
+import { useTodayRanks } from '@/hooks/useTodayRanks';
 
 const AttendanceCard = dynamic(
   () => import('@/components/home/AttendanceCard'),
@@ -34,6 +36,11 @@ const AttendanceCard = dynamic(
 export default function Home() {
   const user = useAtomValue(userAtom);
   const isMember = Boolean(user);
+  const {
+    ranks: todayRanks,
+    isLoading: isTodayRanksLoading,
+    isError: isTodayRanksError,
+  } = useTodayRanks();
 
   return (
     <>
@@ -114,13 +121,11 @@ export default function Home() {
 
       <ExecMessageCard />
 
-      <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[210px]">
-        <div className="flex items-center gap-1 mb-4">
-          <Icon icon="icon-park:trophy" className="w-6 h-6 text-primary-500" />
-          <h2 className="brand-h3 text-grey-900">Today 갓생이</h2>
-        </div>
-        <p className="body-base text-grey-700">1호 갓생이가 되어주세요🐹</p>
-      </section>
+      <TodayRankWidget
+        ranks={todayRanks}
+        isLoading={isTodayRanksLoading}
+        isError={isTodayRanksError}
+      />
     </>
   );
 }

--- a/src/components/home/TodayRankWidget.tsx
+++ b/src/components/home/TodayRankWidget.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { Icon } from '@iconify/react';
+import type { TodayRankUser } from '@/types/todayRank';
+
+export type TodayRankWidgetProps = {
+  ranks: TodayRankUser[];
+  isLoading?: boolean;
+  isError?: boolean;
+};
+
+const clampPercentage = (value: number) => Math.min(Math.max(value, 0), 100);
+
+const calculateScore = (user: TodayRankUser) =>
+  clampPercentage(user.performanceRate) + clampPercentage(user.attendanceRate);
+
+export function TodayRankWidget({
+  ranks,
+  isLoading = false,
+  isError = false,
+}: TodayRankWidgetProps) {
+  const topRanks = ranks
+    .slice()
+    .sort((a, b) => calculateScore(b) - calculateScore(a))
+    .slice(0, 3);
+
+  const renderLoading = () => (
+    <div className="mt-4 flex flex-col gap-3">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div
+          key={index}
+          className="h-9 w-full rounded-[5px] bg-grey-200 animate-pulse"
+        />
+      ))}
+    </div>
+  );
+
+  const renderError = () => (
+    <div className="mt-4 rounded-[5px] border border-grey-200 bg-white/60 p-4">
+      <p className="body-sm text-grey-600">
+        랭킹을 불러오는 중 문제가 발생했어요. 잠시 후 다시 시도해주세요.
+      </p>
+    </div>
+  );
+
+  const renderEmpty = () => (
+    <div className="mt-4 flex flex-col items-start gap-3">
+      <p className="body-base text-grey-900 font-normal">
+        1호 갓생이가 되어 주세요🐹
+      </p>
+    </div>
+  );
+
+  const renderRanks = () => (
+    <ul className="mt-4 flex flex-col gap-4">
+      {topRanks.map((user, index) => {
+        const safePerf = clampPercentage(user.performanceRate);
+        const safeAttend = clampPercentage(user.attendanceRate);
+
+        return (
+          <li
+            key={user.userId}
+            className="grid grid-cols-[minmax(84px,1fr)_83px_83px] items-center gap-2 sm:grid-cols-[122px_83px_83px] sm:gap-4 md:gap-6"
+          >
+            <div className="flex items-center gap-2 min-w-0 w-full overflow-hidden sm:w-[122px]">
+              <span className="brand-h4 text-primary-500 flex-shrink-0">
+                {String(index + 1).padStart(2, '0')}
+              </span>
+              <span className="body-sm text-grey-900 font-semibold truncate whitespace-nowrap">
+                {user.displayName}
+              </span>
+              <span className="body-xs text-grey-500 flex-shrink-0 whitespace-nowrap">
+                {user.departmentName}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5 body-sm w-[83px]">
+              <Icon
+                icon="icon-park-solid:up-two"
+                className="w-4 h-4 text-primary-500"
+              />
+              <span className="body-sm text-grey-500">성과 {safePerf}%</span>
+            </div>
+            <div className="flex items-center gap-1.5 body-sm w-[83px]">
+              <Icon
+                icon="fluent:flash-on-24-filled"
+                className="w-4 h-4 text-primary-500"
+              />
+              <span className="body-sm text-grey-500">근태 {safeAttend}%</span>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+
+  return (
+    <section className="bg-grey-100 rounded-[5px] p-6 flex flex-col gap-2 md:min-h-[210px]">
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-1">
+          <Icon icon="icon-park:trophy" className="w-6 h-6 text-primary-500" />
+          <h2 className="brand-h3 text-grey-900">Today 갓생이</h2>
+        </div>
+      </div>
+
+      {isLoading
+        ? renderLoading()
+        : isError
+          ? renderError()
+          : topRanks.length
+            ? renderRanks()
+            : renderEmpty()}
+    </section>
+  );
+}

--- a/src/hooks/useTodayRanks.ts
+++ b/src/hooks/useTodayRanks.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchTodayRanks } from '@/services/todayRank';
+import type { TodayRankUser } from '@/types/todayRank';
+
+export interface UseTodayRanksResult {
+  ranks: TodayRankUser[];
+  isLoading: boolean;
+  isError: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+type TodayRankPeriod = '1d' | '7d' | '30d';
+
+const PERIOD_DAY_MAP: Record<TodayRankPeriod, number> = {
+  '1d': 1,
+  '7d': 7,
+  '30d': 30,
+};
+
+export function useTodayRanks(
+  period: TodayRankPeriod = '7d',
+  limit = 3
+): UseTodayRanksResult {
+  const [ranks, setRanks] = useState<TodayRankUser[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+  const periodDays = PERIOD_DAY_MAP[period] ?? 7;
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const runFetch = useCallback(async () => {
+    setIsLoading(true);
+    const result = await fetchTodayRanks({
+      periodDays,
+      limit,
+    });
+    if (!isMountedRef.current) return;
+
+    if (result.ok) {
+      setRanks(result.data);
+      setError(null);
+    } else {
+      setRanks([]);
+      setError(result.error);
+    }
+    setIsLoading(false);
+  }, [limit, periodDays]);
+
+  useEffect(() => {
+    void runFetch();
+  }, [runFetch]);
+
+  return {
+    ranks,
+    isLoading,
+    isError: Boolean(error),
+    error,
+    refresh: runFetch,
+  };
+}

--- a/src/services/todayRank.ts
+++ b/src/services/todayRank.ts
@@ -1,0 +1,33 @@
+import type { TodayRankUser } from '@/types/todayRank';
+import { getTodayRanks, type TodayRankOptions } from '@/app/_actions/todayRank';
+
+const DEFAULT_TIMEOUT = 6000;
+
+const withTimeout = <T>(promise: Promise<T>, timeoutMs = DEFAULT_TIMEOUT) =>
+  Promise.race<T>([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error('Request timeout')), timeoutMs)
+    ),
+  ]);
+
+export type TodayRankResult =
+  | { ok: true; data: TodayRankUser[] }
+  | { ok: false; error: string };
+
+export async function fetchTodayRanks(
+  options?: TodayRankOptions
+): Promise<TodayRankResult> {
+  try {
+    const data = await withTimeout(
+      getTodayRanks({
+        periodDays: options?.periodDays ?? 7,
+        limit: options?.limit ?? 3,
+      })
+    );
+    return { ok: true, data };
+  } catch (error) {
+    console.error('[services/todayRank] fetchTodayRanks failed', error);
+    return { ok: false, error: 'UNKNOWN' };
+  }
+}

--- a/src/types/todayRank.ts
+++ b/src/types/todayRank.ts
@@ -1,0 +1,7 @@
+export type TodayRankUser = {
+  userId: string;
+  displayName: string;
+  departmentName: string;
+  performanceRate: number;
+  attendanceRate: number;
+};

--- a/supabase-today-rank-rpc.sql
+++ b/supabase-today-rank-rpc.sql
@@ -1,0 +1,99 @@
+-- ============================================================================
+-- Today 갓생이 랭킹 계산용 RPC (최근 7일 rolling 기준)
+-- ============================================================================
+-- 함수명: get_today_ranks(period_days int default 7, limit_count int default 3)
+-- 반환 컬럼:
+--   user_id UUID
+--   display_name TEXT
+--   department_name TEXT
+--   performance_rate NUMERIC (0~100)
+--   attendance_rate NUMERIC (0~100)
+--
+-- period_days 는 1~30 범위 내 값으로 클램핑하며,
+-- attendance_rate 는 기준 기간 일수 대비 출근일 비율,
+-- performance_rate 는 기간 내 완료된 업무 비율(없으면 profiles.performance_rate)로 계산.
+-- ============================================================================
+
+drop function if exists public.get_today_ranks;
+
+create or replace function public.get_today_ranks(
+  period_days integer default 7,
+  limit_count integer default 3
+)
+returns table (
+  user_id uuid,
+  display_name text,
+  department_name text,
+  performance_rate numeric,
+  attendance_rate numeric
+)
+language sql
+security definer
+set search_path = public
+as $$
+with params as (
+  select
+    greatest(1, least(coalesce(period_days, 7), 30))::int as period_days,
+    greatest(1, coalesce(limit_count, 3))::int as limit_count
+),
+range as (
+  select
+    timezone('Asia/Seoul', now())::date as today,
+    (timezone('Asia/Seoul', now())::date - (select period_days - 1 from params)) as start_date,
+    (select period_days from params) as period_days
+),
+attendance as (
+  select
+    al.user_id,
+    count(*) filter (where al.status is not null and al.status != 'none')::numeric as attended_days
+  from public.attendance_logs al
+  cross join range r
+  where al.work_date between r.start_date and r.today
+  group by al.user_id
+),
+performance as (
+  select
+    t.user_id,
+    count(*)::numeric as total_tasks,
+    count(*) filter (where t.status = 'done')::numeric as done_tasks
+  from public.tasks t
+  cross join range r
+  where (t.created_at at time zone 'Asia/Seoul')::date between r.start_date and r.today
+  group by t.user_id
+),
+profile_base as (
+  select
+    p.id,
+    trim(concat_ws(' ', nullif(p.last_name, ''), nullif(p.first_name, ''))) as raw_name,
+    p.department,
+    0::numeric as fallback_performance
+  from public.profiles p
+) ,
+rank_base as (
+  select
+  pb.id as user_id,
+  coalesce(nullif(pb.raw_name, ''), '익명 사원') as display_name,
+  coalesce(nullif(pb.department, ''), '부서 미정') as department_name,
+  case
+    when perf.total_tasks > 0
+      then round((perf.done_tasks / nullif(perf.total_tasks, 0)) * 100, 2)
+    else pb.fallback_performance
+  end as performance_rate,
+  round(
+    (coalesce(att.attended_days, 0) / (select period_days from range)) * 100,
+    2
+  ) as attendance_rate
+from profile_base pb
+cross join range r
+left join performance perf on perf.user_id = pb.id
+left join attendance att on att.user_id = pb.id
+)
+select *
+from rank_base
+order by
+  (performance_rate + attendance_rate) desc,
+  attendance_rate desc,
+  performance_rate desc,
+  display_name asc
+limit (select limit_count from params);
+$$;


### PR DESCRIPTION
## 📋 작업 내용
- add `get_today_ranks` RPC for rolling 7-day attendance/performance aggregation
- wire Home page + TodayRankWidget to Supabase data via new action/service/hook
- expose loading/error/empty states and add “최근 7일 기준 랭킹” subtitle

## 🎯 관련 이슈
Closes #41 

## 📝 변경사항
- 
- 

## ✅ 체크리스트
- [ ] 코드 리뷰 받을 준비 완료
- [ ] 테스트 완료 
- [ ] 문서 업데이트 (필요시)

## 📸 스크린샷
<img width="440" height="228" alt="Screenshot 2025-11-16 at 22 07 45" src="https://github.com/user-attachments/assets/bb0b70a5-1f03-49fd-8539-2018f88cdb7e" />
