### PR TITLE
[Feat] 게시판 글쓰기 페이지 UI 퍼블리싱 

### DIFF
--- a/src/app/board/new/actions.ts
+++ b/src/app/board/new/actions.ts
@@ -1,0 +1,153 @@
+'use server';
+
+import { z } from 'zod';
+import { redirect } from 'next/navigation';
+import { createServerSupabase } from '@/lib/supabase/server';
+import {
+  getTagsByScope,
+  type BoardScope,
+  isValidBoard,
+} from '@/constants/board';
+
+const boardPostSchema = z.object({
+  scope: z.enum(['company', 'department']),
+  board: z
+    .string()
+    .optional()
+    .transform(value => (value?.trim() ? value.trim() : undefined)),
+  dept: z
+    .string()
+    .optional()
+    .transform(value => (value?.trim() ? value.trim() : undefined)),
+  title: z
+    .string()
+    .trim()
+    .min(1, '제목을 입력해주세요.')
+    .max(100, '제목은 100자 이내로 입력해주세요.'),
+  content: z
+    .string()
+    .trim()
+    .min(5, '본문은 5자 이상 입력해주세요.')
+    .max(3000, '본문은 3000자 이하로 입력해주세요.'),
+  tags: z
+    .array(z.string().trim())
+    .max(5, '태그는 최대 5개까지 선택할 수 있습니다.')
+    .optional()
+    .default([]),
+});
+
+export type CreateBoardPostResult = {
+  ok: boolean;
+  error?: string;
+  fieldErrors?: Partial<Record<'title' | 'content' | 'tags', string>>;
+};
+
+function deriveAuthorName(user: {
+  user_metadata?: Record<string, unknown>;
+  email?: string | null;
+}) {
+  const metadata = user.user_metadata ?? {};
+  const candidates = [
+    metadata['profile_nickname'],
+    metadata['nickname'],
+    metadata['last_name'],
+    metadata['name'],
+    metadata['full_name'],
+    user.email?.split('@')[0],
+  ];
+
+  const display = candidates.find(
+    value => typeof value === 'string' && value.trim().length > 0
+  ) as string | undefined;
+
+  return display?.trim() ?? '익명';
+}
+
+export async function createBoardPost(
+  formData: FormData
+): Promise<CreateBoardPostResult> {
+  const rawScope = String(formData.get('scope') ?? 'company') as BoardScope;
+  const parsed = boardPostSchema.safeParse({
+    scope: rawScope,
+    board: formData.get('board'),
+    dept: formData.get('dept'),
+    title: formData.get('title'),
+    content: formData.get('content'),
+    tags: formData.getAll('tags').map(tag => String(tag)),
+  });
+
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    return {
+      ok: false,
+      error: issue?.message ?? '입력값을 확인해주세요.',
+      fieldErrors: {
+        ...(issue?.path?.[0] === 'title' ? { title: issue.message } : {}),
+        ...(issue?.path?.[0] === 'content' ? { content: issue.message } : {}),
+        ...(issue?.path?.[0] === 'tags' ? { tags: issue.message } : {}),
+      },
+    };
+  }
+
+  const { scope, board, dept, title, content } = parsed.data;
+  const tags = Array.from(new Set(parsed.data.tags ?? []));
+
+  // scope/board/dept 조합 검증
+  if (!isValidBoard(scope, board, dept)) {
+    return {
+      ok: false,
+      error: '유효하지 않은 게시판 정보입니다.',
+    };
+  }
+
+  // 태그 유효성 검증
+  const availableTags = getTagsByScope(scope);
+  const invalidTag = tags.find(
+    tag => !availableTags.includes(tag as (typeof availableTags)[number])
+  );
+  if (invalidTag) {
+    return { ok: false, error: '선택할 수 없는 태그가 포함되어 있습니다.' };
+  }
+
+  const supabase = await createServerSupabase();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return { ok: false, error: '로그인이 필요합니다.' };
+  }
+
+  const authorName = deriveAuthorName(user);
+
+  const { data: inserted, error } = await supabase
+    .from('board_posts')
+    .insert({
+      scope,
+      board: scope === 'company' ? board : null,
+      dept: scope === 'department' ? dept : null,
+      title,
+      content,
+      tags,
+      author_id: user.id,
+      author_name: authorName,
+      view_count: 0,
+      comment_count: 0,
+    })
+    .select('id')
+    .single();
+
+  if (error || !inserted?.id) {
+    console.error('[createBoardPost] insert failed', error);
+    return { ok: false, error: '게시글 저장 중 오류가 발생했습니다.' };
+  }
+
+  const query = new URLSearchParams({
+    scope,
+    ...(scope === 'company' && board ? { board } : {}),
+    ...(scope === 'department' && dept ? { dept } : {}),
+  });
+
+  redirect(`/board/detail/${inserted.id}?${query.toString()}`);
+}

--- a/src/app/board/new/page.tsx
+++ b/src/app/board/new/page.tsx
@@ -1,0 +1,71 @@
+import { redirect } from 'next/navigation';
+import BoardPostForm from '@/components/features/board/BoardPostForm';
+import { createServerSupabase } from '@/lib/supabase/server';
+import {
+  COMPANY_BOARDS,
+  getTagsByScope,
+  isValidBoard,
+  type BoardScope,
+} from '@/constants/board';
+
+export const dynamic = 'force-dynamic';
+
+type BoardNewPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+function resolveScope(rawScope: string | null): BoardScope {
+  return rawScope === 'department' ? 'department' : 'company';
+}
+
+export default async function BoardNewPage({
+  searchParams,
+}: BoardNewPageProps) {
+  const params = (await searchParams) ?? {};
+
+  const scope = resolveScope(
+    typeof params.scope === 'string' ? params.scope : null
+  );
+  const board =
+    typeof params.board === 'string'
+      ? params.board
+      : typeof params.tboard === 'string'
+        ? params.tboard
+        : '';
+  const dept = typeof params.dept === 'string' ? params.dept : '';
+
+  const supabase = await createServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  if (!isValidBoard(scope, board, dept)) {
+    if (scope === 'company') {
+      redirect(
+        `/board?scope=company&board=${encodeURIComponent(COMPANY_BOARDS[0])}`
+      );
+    }
+    redirect(
+      `/board?scope=department${dept ? `&dept=${encodeURIComponent(dept)}` : ''}`
+    );
+  }
+
+  const categoryOptions =
+    scope === 'company' ? [...COMPANY_BOARDS] : dept ? [dept] : [];
+
+  const availableTags = getTagsByScope(scope);
+
+  return (
+    <BoardPostForm
+      scope={scope}
+      board={scope === 'company' ? board : undefined}
+      dept={scope === 'department' ? dept : undefined}
+      availableTags={availableTags}
+      categoryOptions={categoryOptions}
+    />
+  );
+}

--- a/src/components/features/board/BoardHeader.tsx
+++ b/src/components/features/board/BoardHeader.tsx
@@ -6,15 +6,17 @@ import ViewToggle from '@/components/ui/ViewToggle';
 interface BoardHeaderProps {
   toggleView: 'list' | 'grid';
   onViewChange: () => void;
+  onCreate: () => void;
 }
 
 export default function BoardHeader({
   toggleView,
   onViewChange,
+  onCreate,
 }: BoardHeaderProps) {
   return (
     <div className="flex justify-end gap-3">
-      <Button variant="primary" className="py-2 px-6" onClick={() => {}}>
+      <Button variant="primary" className="py-2 px-6" onClick={onCreate}>
         글쓰기
       </Button>
       <ViewToggle view={toggleView} onViewChange={onViewChange} />

--- a/src/components/features/board/BoardListView.tsx
+++ b/src/components/features/board/BoardListView.tsx
@@ -337,6 +337,18 @@ export default function BoardListView() {
     setToggleView(prev => (prev === 'list' ? 'grid' : 'list'));
   };
 
+  const handleCreate = () => {
+    const params = new URLSearchParams();
+    params.set('scope', scope);
+    if (scope === 'company' && board) {
+      params.set('board', board);
+    }
+    if (scope === 'department' && dept) {
+      params.set('dept', dept);
+    }
+    router.push(`/board/new?${params.toString()}`);
+  };
+
   const filteredList = useMemo(() => {
     // 확장 포인트 ②: scope/board/dept 기준으로 리스트 분기
     // - API 연동 시 여기에서 scope/board/dept를 서버 액션 인자로 전달하거나,
@@ -400,6 +412,7 @@ export default function BoardListView() {
             <BoardHeader
               toggleView={toggleView}
               onViewChange={handleViewChange}
+              onCreate={handleCreate}
             />
           </div>
         </div>

--- a/src/components/features/board/BoardPostForm.tsx
+++ b/src/components/features/board/BoardPostForm.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import { useRef, useState, useTransition, type KeyboardEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { Icon } from '@iconify/react';
+import Button from '@/components/ui/Button';
+import Select from '@/components/ui/Select';
+import { createBoardPost } from '@/app/board/new/actions';
+import type { BoardScope } from '@/constants/board';
+
+type BoardPostFormProps = {
+  scope: BoardScope;
+  board?: string;
+  dept?: string;
+  availableTags: string[];
+  categoryOptions: string[];
+};
+
+type FieldErrors = Partial<
+  Record<'title' | 'content' | 'tags' | 'form', string>
+>;
+
+const TOOLBAR_ACTIONS = [
+  { icon: 'material-symbols:imagesmode-outline', label: '이미지 첨부' },
+  { icon: 'material-symbols:format-bold-rounded', label: '굵게' },
+  { icon: 'material-symbols:format-italic-rounded', label: '이탤릭' },
+  { icon: 'material-symbols:format-underlined-rounded', label: '밑줄' },
+  { icon: 'material-symbols:format-strikethrough-rounded', label: '가로줄' },
+  { icon: 'material-symbols:format-color-fill-rounded', label: '배경색' },
+  { icon: 'material-symbols:format-paint-rounded', label: '텍스트색' },
+  { icon: 'material-symbols:format-size-rounded', label: '사이즈' },
+  { icon: 'material-symbols:link-rounded', label: '링크 첨부' },
+  { icon: 'material-symbols:attach-file', label: '파일 첨부' },
+];
+
+export default function BoardPostForm({
+  scope,
+  board,
+  dept,
+  availableTags,
+  categoryOptions,
+}: BoardPostFormProps) {
+  const router = useRouter();
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [tagSelectValue, setTagSelectValue] = useState<string | undefined>();
+  const [tagInput, setTagInput] = useState('');
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [isPending, startTransition] = useTransition();
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const listHref =
+    scope === 'company'
+      ? `/board?scope=company&board=${encodeURIComponent(board ?? categoryOptions[0] ?? '')}`
+      : `/board?scope=department&dept=${encodeURIComponent(dept ?? '')}`;
+
+  const addTagFromInput = () => {
+    const raw = tagInput.trim();
+    if (!raw) return;
+
+    const cleaned = raw.replace(/^#+/, '').replace(/,+$/, '').trim();
+
+    if (!cleaned) {
+      setTagInput('');
+      return;
+    }
+
+    setSelectedTags(prev => {
+      if (prev.includes(cleaned)) return prev;
+      return [...prev, cleaned].slice(0, 5);
+    });
+
+    setTagInput('');
+  };
+
+  const handleTagKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    // IME(한글 등) 조합 중일 때는 태그 변환을 막기
+    const nativeEvent = e.nativeEvent as unknown as { isComposing?: boolean };
+    if (nativeEvent.isComposing) return;
+
+    if (e.key === 'Enter' || e.key === ' ' || e.key === ',') {
+      e.preventDefault();
+      addTagFromInput();
+    }
+  };
+
+  const handleTagBlur = () => {
+    // 인풋에서 포커스가 빠질 때 남은 텍스트를 태그로 변환
+    addTagFromInput();
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    setSelectedTags(prev => prev.filter(t => t !== tag));
+  };
+
+  const handleCancel = () => {
+    router.push(listHref);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    addTagFromInput();
+    const newErrors: FieldErrors = {};
+
+    if (!title.trim()) {
+      newErrors.title = '제목을 입력해주세요.';
+    }
+
+    if (content.trim().length < 5) {
+      newErrors.content = '본문은 5자 이상 입력해주세요.';
+    }
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    startTransition(async () => {
+      try {
+        const fd = new FormData(formRef.current ?? undefined);
+        fd.set('scope', scope);
+        if (board) fd.set('board', board);
+        if (dept) fd.set('dept', dept);
+        fd.set('title', title.trim());
+        fd.set('content', content.trim());
+        fd.delete('tags');
+        Array.from(new Set(selectedTags)).forEach(tag =>
+          fd.append('tags', tag)
+        );
+
+        const result = await createBoardPost(fd);
+
+        if (!result.ok) {
+          setErrors({
+            title: result.fieldErrors?.title,
+            content: result.fieldErrors?.content,
+            tags: result.fieldErrors?.tags,
+            form: result.error,
+          });
+        }
+      } catch (error) {
+        console.error('[BoardPostForm] submit failed', error);
+        setErrors({
+          form: '요청 처리 중 오류가 발생했습니다.',
+        });
+      }
+    });
+  };
+
+  return (
+    <main className="flex-1 px-6 md:px-6 py-6 bg-grey-100 col-span-2 space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <h2 className="brand-h2 font-brand text-grey-900">글쓰기</h2>
+        </div>
+        <Button
+          type="button"
+          variant="primary"
+          size="md"
+          className="px-6"
+          onClick={() => router.push(listHref)}
+        >
+          목록
+        </Button>
+      </div>
+      <div className="border-b border-grey-200 my-4" />
+
+      <div className="space-y-2">
+        <Select
+          placeholder="분류 선택"
+          value={tagSelectValue}
+          onChange={value => {
+            // 분류 선택은 해시태그와 별도로 동작 (태그 리스트에는 추가하지 않음)
+            setTagSelectValue(value);
+          }}
+          options={availableTags.map(tag => ({
+            value: tag,
+            label: tag,
+          }))}
+        />
+        {errors.tags && (
+          <p className="body-xs text-[#e26aff] font-medium">{errors.tags}</p>
+        )}
+      </div>
+
+      <form ref={formRef} onSubmit={handleSubmit}>
+        <div className="bg-white rounded-[5px] border border-grey-200">
+          <div className="pt-4">
+            <div className="flex items-center gap-3 px-4 pb-3 flex-wrap">
+              {TOOLBAR_ACTIONS.map(action => (
+                <button
+                  key={action.icon}
+                  type="button"
+                  onClick={() => alert('준비 중')}
+                  className="flex items-center gap-1 px-2 py-1 rounded-[4px] hover:bg-grey-100 transition-colors"
+                >
+                  <Icon icon={action.icon} className="w-5 h-5 text-grey-800" />
+                </button>
+              ))}
+            </div>
+            <div className="border-t border-grey-200" />
+
+            <div className="px-6 py-5 space-y-3">
+              <div>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={e => setTitle(e.target.value)}
+                  placeholder="제목을 입력해 주세요"
+                  maxLength={100}
+                  className="w-full bg-transparent border-none outline-none text-xl font-medium text-grey-900 placeholder:text-grey-300"
+                />
+                {errors.title && (
+                  <p className="mt-1 text-xs text-[#e26aff]">{errors.title}</p>
+                )}
+              </div>
+              <div>
+                <textarea
+                  value={content}
+                  onChange={e => setContent(e.target.value)}
+                  placeholder="갓생이들에게 전할 말 🐴"
+                  maxLength={3000}
+                  rows={10}
+                  className="w-full bg-transparent border-none outline-none resize-none text-base text-grey-900 placeholder:text-grey-300 min-h-[260px]"
+                />
+                {errors.content && (
+                  <p className="mt-1 text-xs text-[#e26aff]">
+                    {errors.content}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="px-6 pb-4">
+              <div className="flex flex-wrap gap-2">
+                {selectedTags.map(tag => (
+                  <div
+                    key={tag}
+                    className="inline-flex items-center gap-2 rounded-[999px] bg-primary-100 px-3 py-1 text-primary-500 text-sm"
+                  >
+                    <span>#{tag}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveTag(tag)}
+                      className="text-xs text-primary-400 hover:text-primary-600"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+
+                <div className="w-26 h-8 px-4 py-2 bg-primary-100 rounded-[5px] inline-flex justify-center items-center gap-2.5">
+                  <input
+                    type="text"
+                    value={tagInput}
+                    onChange={e => setTagInput(e.target.value)}
+                    onKeyDown={handleTagKeyDown}
+                    onBlur={handleTagBlur}
+                    placeholder={selectedTags.length === 0 ? '#태그 입력' : ''}
+                    className="w-full bg-transparent border-none outline-none text-primary-500 text-sm font-medium leading-6 placeholder:text-primary-500"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-5 space-y-3">
+          <div className="rounded-[5px] border border-dashed border-grey-300 bg-grey-50 px-4 py-3">
+            <div className="flex items-center gap-2 text-grey-700 body-sm">
+              <Icon icon="material-symbols:attach-file" className="w-5 h-5" />
+              <span>첨부 파일 없음</span>
+            </div>
+          </div>
+
+          {errors.form && (
+            <div className="rounded-[5px] bg-[#ffe6ff] border border-[#e26aff] px-3 py-2 text-[#7d1bbd] body-sm">
+              {errors.form}
+            </div>
+          )}
+        </div>
+
+        <div className="mt-5 flex flex-col gap-3 md:flex-row md:gap-4">
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            className="w-full md:flex-1 bg-white text-grey-700 border border-grey-200"
+            onClick={handleCancel}
+          >
+            취소
+          </Button>
+          <Button
+            type="submit"
+            variant="primary"
+            size="lg"
+            className="w-full md:flex-1"
+            disabled={isPending}
+          >
+            {isPending ? '등록 중...' : '등록하기'}
+          </Button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/src/constants/board.ts
+++ b/src/constants/board.ts
@@ -1,0 +1,32 @@
+export const COMPANY_BOARDS = [
+  '공지사항',
+  '성과보고',
+  '체력단련실',
+  '브레인연료',
+  '사내신문고',
+] as const;
+
+export const COMPANY_TAGS = ['공지', '정보', '질문', '잡담', '모집'] as const;
+export const DEPARTMENT_TAGS = [
+  '공지',
+  '정보',
+  '질문',
+  '모집',
+  '잡담',
+] as const;
+
+export type BoardScope = 'company' | 'department';
+
+export function getTagsByScope(scope: BoardScope) {
+  return scope === 'company' ? [...COMPANY_TAGS] : [...DEPARTMENT_TAGS];
+}
+
+export function isValidBoard(scope: BoardScope, board?: string, dept?: string) {
+  if (scope === 'company') {
+    return board
+      ? COMPANY_BOARDS.includes(board as (typeof COMPANY_BOARDS)[number])
+      : false;
+  }
+
+  return !!(dept && dept.trim());
+}


### PR DESCRIPTION
## 📋 작업 내용
게시판 글쓰기 페이지 UI 퍼블리싱 및 게시글 생성 기능 구현 #80에서 **“UI 퍼블리싱 파트”**만 먼저 반영하는 PR

## 🎯 관련 이슈
Closes #80 

## 📝 변경사항
### 폼 UI 퍼블리싱

- 툴바 영역
  - 디자인에 있는 에디터 툴바 아이콘들(iconify) 버튼으로 구현
  - 아직 실제 텍스트 스타일링 기능은 미구현 (alert('준비 중') 처리)

- 제목 입력
  - 단일 라인 인풋
  - placeholder: `제목을 입력해 주세요`
  - 100자 제한

- 본문 입력
  - textarea 기반
  - 3000자 제한
  - resize 불가, 카드 내부에서 깔끔하게 표시되도록 스타일링

- 태그 입력 UI
  - `#태그 입력` pill 스타일 유지하면서,
  - 자유 입력 태그 기능 추가:
    - 키워드 입력 후 `Space`, `,`(콤마), `Enter` 입력 시 태그로 확정
    - 태그는 최대 5개까지
    - 이미 추가된 태그는 중복 추가 방지
    - 태그는 `#키워드` 형태로 칩으로 표시되고, `×` 버튼으로 제거 가능
  - 한글 입력 시(IMEs) 글자가 두 번 생기지 않도록 `isComposing` 처리

- 분류 선택 Select
  - 상단 `분류 선택` 드롭다운은 **현재는 태그와 별개로 동작**하도록 분리 

- 하단 버튼 영역
  - `취소`, `등록하기` 버튼
  - 모바일: 세로 스택 + full width
  - 태블릿 이상: 가로 배치 + flex-1 레이아웃
  - 스타일은 SignupForm과 동일한 토큰/타이포 사용

### 반응형 처리
- 모바일 기준
  - 상단 헤더/버튼/폼 카드가 세로 플로우로 정렬
  - 하단 버튼 두 개는 세로로 쌓이고 가로 폭은 `w-full`
- md 이상
  - 버튼 두 개 나란히 배치 (`md:flex-row`)

## ✅ 체크리스트
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] 주요 브라우저(width 기준)에서 UI 깨짐 없는지 수동 확인

## 📸 스크린샷
<img width="1204" height="966" alt="Screenshot 2025-11-23 at 01 05 57" src="https://github.com/user-attachments/assets/14b0c4e0-3033-40f3-a351-04df73f9257f" />
