### PR TITLE
[Feat] board create to detail #89

### DIFF
--- a/src/app/board/[postId]/page.tsx
+++ b/src/app/board/[postId]/page.tsx
@@ -1,18 +1,76 @@
+import { notFound } from 'next/navigation';
 import { BoardPostView } from '@/components/features/board-post/BoardPostView';
 import { CommentSection } from '@/components/features/board-post/comment/CommentSection';
+import { createServerSupabase } from '@/lib/supabase/server';
+
+type BoardDetailPageProps = {
+  params: Promise<{ postId: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+const DEFAULT_COMPANY_BOARD = '공지사항';
+const DEFAULT_DEPT = 'IT부';
 
 export default async function BoardPostPage({
   params,
-}: {
-  params: Promise<{ postId: string }>;
-}) {
+  searchParams,
+}: BoardDetailPageProps) {
   const { postId } = await params;
-  // api getPost
+  const query = (await searchParams) ?? {};
+
+  const scope =
+    typeof query.scope === 'string' && query.scope === 'department'
+      ? 'department'
+      : 'company';
+  const board = typeof query.board === 'string' ? query.board : undefined;
+  const dept = typeof query.dept === 'string' ? query.dept : undefined;
+
+  const listHref =
+    scope === 'company'
+      ? `/board?scope=company&board=${encodeURIComponent(
+          board ?? DEFAULT_COMPANY_BOARD
+        )}`
+      : `/board?scope=department&dept=${encodeURIComponent(dept ?? DEFAULT_DEPT)}`;
+
+  const supabase = await createServerSupabase();
+  const { data: post, error } = await supabase
+    .from('board_posts')
+    .select(
+      'id, scope, board, dept, topic, title, content, hashtags, author_name, created_at'
+    )
+    .eq('id', postId)
+    .maybeSingle();
+
+  if (error || !post) {
+    console.error('[BoardPostPage] post fetch failed', error);
+    notFound();
+  }
+
+  const postForView = {
+    id: post.id,
+    topic: post.topic ?? '정보',
+    title: post.title,
+    commentCount:
+      ((post as Record<string, unknown>)['comment_count'] as
+        | number
+        | undefined) ?? 0,
+    userName: post.author_name ?? '익명',
+    viewCount:
+      ((post as Record<string, unknown>)['view_count'] as number | undefined) ??
+      0,
+    dateCreated: post.created_at,
+    content: post.content,
+    hashtags: post.hashtags ?? [],
+    boardLabel:
+      post.scope === 'company'
+        ? (post.board ?? '전사게시판')
+        : (post.dept ?? '부서게시판'),
+  };
 
   return (
     <main className="col-span-2 max-w-[1440px]">
-      <BoardPostView postId={postId} />
-      <CommentSection postId={postId} commentCount={11} />
+      <BoardPostView post={postForView} listHref={listHref} />
+      <CommentSection postId={postId} commentCount={postForView.commentCount} />
     </main>
   );
 }

--- a/src/app/board/_actions/listBoardPosts.ts
+++ b/src/app/board/_actions/listBoardPosts.ts
@@ -1,0 +1,61 @@
+'use server';
+
+import { createServerSupabase } from '@/lib/supabase/server';
+import type { BoardScope } from '@/constants/board';
+
+export type BoardPostRow = {
+  id: string;
+  scope: BoardScope;
+  board: string | null;
+  dept: string | null;
+  title: string;
+  content: string;
+  topic: string | null;
+  hashtags: string[] | null;
+  author_name: string | null;
+  view_count?: number | null;
+  comment_count?: number | null;
+  created_at: string;
+};
+
+type ListParams = {
+  scope: BoardScope;
+  board?: string;
+  dept?: string;
+  limit?: number;
+};
+
+export async function listBoardPostsForList({
+  scope,
+  board,
+  dept,
+  limit = 20,
+}: ListParams): Promise<BoardPostRow[]> {
+  const supabase = await createServerSupabase();
+
+  const query = supabase
+    .from('board_posts')
+    .select(
+      'id, scope, board, dept, topic, title, content, hashtags, author_name, created_at'
+    )
+    .eq('scope', scope)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (scope === 'company' && board) {
+    query.eq('board', board);
+  }
+
+  if (scope === 'department' && dept) {
+    query.eq('dept', dept);
+  }
+
+  const { data, error } = await query;
+
+  if (error || !data) {
+    console.error('[listBoardPostsForList] fetch failed', error);
+    return [];
+  }
+
+  return data as BoardPostRow[];
+}

--- a/src/app/board/page.tsx
+++ b/src/app/board/page.tsx
@@ -2,6 +2,7 @@ export const dynamic = 'force-dynamic';
 
 import { Suspense } from 'react';
 import BoardListView from '@/components/features/board/BoardListView';
+import { listBoardPostsForList } from './_actions/listBoardPosts';
 
 type BoardPageProps = {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
@@ -11,7 +12,9 @@ export default async function BoardPage({ searchParams }: BoardPageProps) {
   const params = (await searchParams) ?? {};
 
   const scopeParam =
-    typeof params.scope === 'string' ? params.scope : 'company';
+    typeof params.scope === 'string' && params.scope === 'department'
+      ? 'department'
+      : 'company';
   const boardParam =
     typeof params.board === 'string'
       ? params.board
@@ -20,18 +23,12 @@ export default async function BoardPage({ searchParams }: BoardPageProps) {
         : '';
   const deptParam = typeof params.dept === 'string' ? params.dept : '';
 
-  const boardQueryForFetch = {
+  const livePosts = await listBoardPostsForList({
     scope: scopeParam,
-    board: boardParam,
-    dept: deptParam,
-    tags: params.tag,
-    keyword: params.keyword,
-    page: params.page,
-  };
-
-  // NOTE: API 연동 시 위 boardQueryForFetch 값을 서버 액션(fetchBoardPosts 등)에 전달하고,
-  //       응답 리스트를 <BoardListView initialItems={posts} /> 형태로 내려주면 된다.
-  void boardQueryForFetch;
+    board: boardParam || undefined,
+    dept: deptParam || undefined,
+    limit: 20,
+  });
 
   return (
     <main className="bg-grey-100 rounded-[5px] px-[25px] py-5 mb-5 col-span-2">
@@ -47,7 +44,7 @@ export default async function BoardPage({ searchParams }: BoardPageProps) {
           </div>
         }
       >
-        <BoardListView />
+        <BoardListView livePosts={livePosts} />
       </Suspense>
     </main>
   );

--- a/src/components/features/board-post/BoardPostView.tsx
+++ b/src/components/features/board-post/BoardPostView.tsx
@@ -4,27 +4,39 @@ import { useRouter } from 'next/navigation';
 import { PostCard } from './card/PostCard';
 
 interface BoardPostViewProps {
-  postId: string;
+  post: {
+    id: string;
+    topic: string;
+    title: string;
+    commentCount: number;
+    userName: string;
+    viewCount: number;
+    dateCreated: string;
+    content: string;
+    hashtags: string[];
+    boardLabel: string;
+  };
+  listHref: string;
 }
 
-export function BoardPostView({ postId }: BoardPostViewProps) {
+export function BoardPostView({ post, listHref }: BoardPostViewProps) {
   const router = useRouter();
 
   return (
     <>
       <div className="bg-grey-100 mb-5 rounded-[5px] py-5">
         <div className="flex justify-between pb-4 mb-4 border-b border-b-[#EAEAEA] px-6">
-          <h2 className="brand-h3 text-grey-900 mb-4">IT부</h2>
+          <h2 className="brand-h3 text-grey-900 mb-4">{post.boardLabel}</h2>
           <Button
             variant="primary"
             className="py-2 px-6"
-            onClick={() => router.push('/board')}
+            onClick={() => router.push(listHref)}
           >
             목록보기
           </Button>
         </div>
 
-        <PostCard />
+        <PostCard post={post} />
       </div>
     </>
   );

--- a/src/components/features/board-post/card/Hashtags.tsx
+++ b/src/components/features/board-post/card/Hashtags.tsx
@@ -1,11 +1,13 @@
 interface HashtagsProps {
-  tags: string[];
+  hashtags: string[];
 }
 
-export function Hashtags({ tags }: HashtagsProps) {
+export function Hashtags({ hashtags }: HashtagsProps) {
+  if (!hashtags?.length) return null;
+
   return (
     <div className="mb-10 flex gap-6 px-6">
-      {tags.map(tag => (
+      {hashtags.map(tag => (
         <div className=" text-sm text-grey-500" key={tag}>
           #{tag}
         </div>

--- a/src/components/features/board-post/card/PostCard.tsx
+++ b/src/components/features/board-post/card/PostCard.tsx
@@ -4,28 +4,27 @@ import { PostActionBar } from './PostActionBar';
 import PostCardHeader from './PostCardHeader';
 import { PostContent } from './PostContent';
 
-const item = {
-  id: 25,
-  label: '정보',
-  title: 'API 문서 작성 가이드',
-  commentCount: 4,
-  userName: 'CTO 갓햄',
-  viewCount: 95,
-  dateCreated: '2025.03.20',
-  content: `
-    <p>안녕하세요</p>
-    <p>프론트엔드 팀원 모집합니다.</p>`,
-  tags: ['모각코', '리액트', '프로젝트'],
-  likes: 13,
+type PostCardProps = {
+  post: {
+    id: string;
+    topic: string;
+    title: string;
+    commentCount: number;
+    userName: string;
+    viewCount: number;
+    dateCreated: string;
+    content: string;
+    hashtags: string[];
+  };
 };
 
-export function PostCard() {
+export function PostCard({ post }: PostCardProps) {
   return (
     <>
-      <PostCardHeader {...item} />
-      <PostContent content={item.content} />
-      <Hashtags tags={item.tags} />
-      <PostActionBar likes={item.likes} />
+      <PostCardHeader {...post} />
+      <PostContent content={post.content} />
+      <Hashtags hashtags={post.hashtags} />
+      <PostActionBar likes={0} />
     </>
   );
 }

--- a/src/components/features/board-post/card/PostCardHeader.tsx
+++ b/src/components/features/board-post/card/PostCardHeader.tsx
@@ -3,8 +3,8 @@ import Badge from '@/components/ui/Badge';
 import IconButton from '@/components/ui/IconButton';
 
 interface BoardPostHeaderProps {
-  id: number;
-  label: string;
+  id: string;
+  topic: string;
   title: string;
   commentCount: number;
   userName: string;
@@ -13,7 +13,7 @@ interface BoardPostHeaderProps {
 }
 
 export default function PostCardHeader({
-  label,
+  topic,
   title,
   commentCount,
   userName,
@@ -26,7 +26,7 @@ export default function PostCardHeader({
     <div className="space-y-3 mb-9 pl-6">
       <div className="flex justify-between items-center">
         <Badge variant="blue" size="xs" className="text-[12px]">
-          {label}
+          {topic}
         </Badge>
         {/* TODO: 버튼 클릭시 드롭다운 */}
         <IconButton icon="icon-park:more-one" variant="ghost" />

--- a/src/components/features/board-post/card/PostContent.tsx
+++ b/src/components/features/board-post/card/PostContent.tsx
@@ -4,11 +4,9 @@ interface PostContentProps {
 }
 
 export function PostContent({ content }: PostContentProps) {
-  // TODO: 콘텐츠는 일반 문자열보다 이미지, 리치텍스트를 지원하기 위해 html 저장 방식이 좋을 듯 함
   return (
-    <div
-      className="mb-[22px] px-6 prose prose-sm max-w-none"
-      dangerouslySetInnerHTML={{ __html: content }}
-    />
+    <div className="mb-[22px] px-6 text-base leading-6 whitespace-pre-wrap">
+      {content}
+    </div>
   );
 }

--- a/src/components/features/board-post/comment/CommentInput.tsx
+++ b/src/components/features/board-post/comment/CommentInput.tsx
@@ -10,7 +10,10 @@ interface CommentInputProps {
   onCommentAdded?: () => void;
 }
 
-export function CommentInput({ postId, onCommentAdded }: CommentInputProps) {
+export function CommentInput({
+  postId: _postId,
+  onCommentAdded,
+}: CommentInputProps) {
   const [content, setContent] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 

--- a/src/components/features/board/BoardItem.tsx
+++ b/src/components/features/board/BoardItem.tsx
@@ -1,15 +1,17 @@
 'use client';
 
+import Link from 'next/link';
 import Badge from '@/components/ui/Badge';
 
 interface BoardItemProps {
-  id: number;
+  id: string;
   topic: string;
   title: string;
   commentCount: number;
   userName: string;
   viewCount: number;
   dateCreated: string;
+  href?: string;
 }
 
 export default function BoardItem({
@@ -19,10 +21,11 @@ export default function BoardItem({
   userName,
   viewCount,
   dateCreated,
+  href,
 }: BoardItemProps) {
   const formatViewCount = viewCount >= 9999 ? '9999+' : viewCount;
 
-  return (
+  const content = (
     <div className="py-3 border-t border-t-grey-200 last:border-b last:border-b-grey-200">
       <div className="flex gap-2 mb-[10px] items-center">
         <Badge variant="blue" size="xs" className="text-[12px]">
@@ -39,5 +42,16 @@ export default function BoardItem({
         <span>{dateCreated}</span>
       </div>
     </div>
+  );
+
+  if (!href) return content;
+
+  return (
+    <Link
+      href={href}
+      className="block hover:bg-grey-50 transition-colors rounded-[4px]"
+    >
+      {content}
+    </Link>
   );
 }

--- a/src/components/features/board/BoardListView.tsx
+++ b/src/components/features/board/BoardListView.tsx
@@ -19,8 +19,22 @@ import BoardFilterTopics from './BoardFilterTopics';
 import BoardHeader from './BoardHeader';
 import BoardItem from './BoardItem';
 
+type BoardListViewProps = {
+  livePosts?: {
+    id: string;
+    topic: string | null;
+    title: string;
+    comment_count?: number | null;
+    author_name: string | null;
+    view_count?: number | null;
+    created_at: string;
+    board?: string | null;
+    dept?: string | null;
+  }[];
+};
+
 type BoardListItem = {
-  id: number;
+  id: string;
   topic: string;
   title: string;
   commentCount: number;
@@ -49,9 +63,13 @@ const COMPANY_BOARDS = [
 const COMPANY_TOPICS = ['공지', '정보', '질문', '잡담', '모집'] as const;
 const DEPARTMENT_TOPICS = ['공지', '정보', '질문', '모집', '잡담'] as const;
 
+const DEMO_POST_ID = '24c0a64c-70bd-4d97-8996-e9d836a0466c';
+const isUuid = (id: string) =>
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+
 const mockList: Omit<BoardListItem, 'board'>[] = [
   {
-    id: 1,
+    id: '1',
     topic: '공지',
     title: '03/31 공지사항입니다.',
     commentCount: 3,
@@ -60,7 +78,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.31',
   },
   {
-    id: 2,
+    id: '2',
     topic: '모집',
     title: '프론트엔드팀 팀원 모집',
     commentCount: 2,
@@ -69,7 +87,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.31',
   },
   {
-    id: 3,
+    id: '3',
     topic: '정보',
     title: '8월 오프라인 세미나 일정',
     commentCount: 12,
@@ -78,7 +96,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.31',
   },
   {
-    id: 4,
+    id: '4',
     topic: '잡담',
     title: '이건 무슨 벌레인가요?',
     commentCount: 5,
@@ -87,7 +105,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.31',
   },
   {
-    id: 5,
+    id: '5',
     topic: '질문',
     title: 'React 18 마이그레이션 질문',
     commentCount: 8,
@@ -96,7 +114,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.30',
   },
   {
-    id: 6,
+    id: '6',
     topic: '정보',
     title: '신규 프로젝트 킥오프 미팅',
     commentCount: 15,
@@ -105,7 +123,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.30',
   },
   {
-    id: 7,
+    id: '7',
     topic: '모집',
     title: '백엔드 개발자 모집합니다',
     commentCount: 7,
@@ -114,7 +132,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.29',
   },
   {
-    id: 8,
+    id: '8',
     topic: '잡담',
     title: '점심 메뉴 추천해주세요',
     commentCount: 20,
@@ -123,7 +141,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.29',
   },
   {
-    id: 9,
+    id: '9',
     topic: '공지',
     title: '4월 정기 회식 공지',
     commentCount: 5,
@@ -132,7 +150,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.28',
   },
   {
-    id: 10,
+    id: '10',
     topic: '질문',
     title: 'TypeScript 타입 에러 해결 방법',
     commentCount: 11,
@@ -141,7 +159,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.28',
   },
   {
-    id: 11,
+    id: '11',
     topic: '정보',
     title: '새로운 디자인 시스템 도입',
     commentCount: 9,
@@ -150,7 +168,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.27',
   },
   {
-    id: 12,
+    id: '12',
     topic: '모집',
     title: 'UI/UX 디자이너 구합니다',
     commentCount: 4,
@@ -159,7 +177,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.27',
   },
   {
-    id: 13,
+    id: '13',
     topic: '잡담',
     title: '주말에 뭐하셨나요?',
     commentCount: 18,
@@ -168,7 +186,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.26',
   },
   {
-    id: 14,
+    id: '14',
     topic: '질문',
     title: 'Next.js 14 App Router 관련 질문',
     commentCount: 6,
@@ -177,7 +195,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.26',
   },
   {
-    id: 15,
+    id: '15',
     topic: '공지',
     title: '보안 정책 업데이트 안내',
     commentCount: 2,
@@ -186,7 +204,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.25',
   },
   {
-    id: 16,
+    id: '16',
     topic: '정보',
     title: '코드 리뷰 가이드라인',
     commentCount: 13,
@@ -195,7 +213,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.25',
   },
   {
-    id: 17,
+    id: '17',
     topic: '모집',
     title: 'DevOps 엔지니어 채용',
     commentCount: 3,
@@ -204,7 +222,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.24',
   },
   {
-    id: 18,
+    id: '18',
     topic: '잡담',
     title: '추천하는 개발 도서 있나요?',
     commentCount: 22,
@@ -213,7 +231,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.24',
   },
   {
-    id: 19,
+    id: '19',
     topic: '질문',
     title: 'Git 브랜치 전략 문의',
     commentCount: 8,
@@ -222,7 +240,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.23',
   },
   {
-    id: 20,
+    id: '20',
     topic: '정보',
     title: '5월 컨퍼런스 참가 안내',
     commentCount: 7,
@@ -231,7 +249,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.23',
   },
   {
-    id: 21,
+    id: '21',
     topic: '공지',
     title: '재택근무 정책 변경',
     commentCount: 16,
@@ -240,7 +258,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.22',
   },
   {
-    id: 22,
+    id: '22',
     topic: '모집',
     title: 'QA 엔지니어 모집',
     commentCount: 5,
@@ -249,7 +267,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.22',
   },
   {
-    id: 23,
+    id: '23',
     topic: '잡담',
     title: '요즘 핫한 기술 스택',
     commentCount: 25,
@@ -258,7 +276,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.21',
   },
   {
-    id: 24,
+    id: '24',
     topic: '질문',
     title: 'Docker 컨테이너 최적화 방법',
     commentCount: 10,
@@ -267,7 +285,7 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
     dateCreated: '2025.03.21',
   },
   {
-    id: 25,
+    id: '25',
     topic: '정보',
     title: 'API 문서 작성 가이드',
     commentCount: 4,
@@ -277,12 +295,21 @@ const mockList: Omit<BoardListItem, 'board'>[] = [
   },
 ];
 
-const allList: BoardListItem[] = mockList.map((item, index) => ({
+const mockListWithBoard: BoardListItem[] = mockList.map((item, index) => ({
   ...item,
   board: COMPANY_BOARDS[index % COMPANY_BOARDS.length],
 }));
 
-export default function BoardListView() {
+function formatDate(dateIso: string) {
+  const d = new Date(dateIso);
+  if (Number.isNaN(d.getTime())) return dateIso;
+  const yyyy = d.getFullYear();
+  const mm = `${d.getMonth() + 1}`.padStart(2, '0');
+  const dd = `${d.getDate()}`.padStart(2, '0');
+  return `${yyyy}.${mm}.${dd}`;
+}
+
+export default function BoardListView({ livePosts = [] }: BoardListViewProps) {
   const [toggleView, setToggleView] = useState<'list' | 'grid'>('list');
 
   const searchParams = useSearchParams();
@@ -294,6 +321,27 @@ export default function BoardListView() {
   const selectedTopics = searchParams.getAll('topic');
   const currentPage = Number(searchParams.get('page')) || 1;
   const keyword = searchParams.get('keyword') || '';
+
+  const supabaseList: BoardListItem[] = useMemo(
+    () =>
+      livePosts.map(post => ({
+        id: post.id,
+        topic: post.topic ?? '공지',
+        title: post.title,
+        commentCount: post.comment_count ?? 0,
+        userName: post.author_name ?? '익명 갓생',
+        viewCount: post.view_count ?? 0,
+        dateCreated: formatDate(post.created_at),
+        board: post.board ?? undefined,
+        dept: post.dept ?? undefined,
+      })),
+    [livePosts]
+  );
+
+  const allList: BoardListItem[] = useMemo(
+    () => [...supabaseList, ...mockListWithBoard],
+    [supabaseList]
+  );
 
   // scope에 따라 노출할 토픽 집합을 분기
   const availableTopics = useMemo(() => {
@@ -383,7 +431,7 @@ export default function BoardListView() {
     }
 
     return result;
-  }, [scope, board, dept, selectedTopics, keyword]);
+  }, [scope, board, dept, selectedTopics, keyword, allList]);
 
   // 페이지네이션 계산
   const totalPages = Math.ceil(filteredList.length / ITEMS_PER_PAGE);
@@ -424,9 +472,24 @@ export default function BoardListView() {
             <p>등록된 게시글이 없습니다.</p>
           ) : (
             <>
-              {currentList.map(item => (
-                <BoardItem key={item.id} {...item} />
-              ))}
+              {currentList.map(item => {
+                const params = new URLSearchParams();
+                params.set('scope', scope);
+                if (scope === 'company' && board) {
+                  params.set('board', board);
+                }
+                if (scope === 'department' && dept) {
+                  params.set('dept', dept);
+                }
+
+                const query = params.toString();
+                const postIdForHref = isUuid(item.id) ? item.id : DEMO_POST_ID;
+                const detailHref = query
+                  ? `/board/${postIdForHref}?${query}`
+                  : `/board/${postIdForHref}`;
+
+                return <BoardItem key={item.id} {...item} href={detailHref} />;
+              })}
             </>
           )}
         </div>

--- a/src/components/features/board/BoardPostForm.tsx
+++ b/src/components/features/board/BoardPostForm.tsx
@@ -154,8 +154,20 @@ export default function BoardPostForm({
           return;
         }
 
-        // 임시: 상세 페이지 작업 중이므로 목록으로 이동
-        router.push(listHref);
+        const searchParams = new URLSearchParams();
+        searchParams.set('scope', scope);
+        if (scope === 'company' && board) {
+          searchParams.set('board', board);
+        }
+        if (scope === 'department' && dept) {
+          searchParams.set('dept', dept);
+        }
+
+        if (result.postId) {
+          router.push(`/board/${result.postId}?${searchParams.toString()}`);
+        } else {
+          router.push(listHref);
+        }
       } catch (error) {
         console.error('[BoardPostForm] submit failed', error);
         setErrors({


### PR DESCRIPTION
## 📋 작업 내용
- 게시글 작성 성공 시 scope/board/dept 쿼리를 포함해 /board/{postId}로 이동하도록 수정 
   - (src/components/features/board/BoardPostForm.tsx).
- Supabase 게시글 리스트를 서버 액션으로 조회해 목록 페이지에 주입하고, 실데이터를 mock 위에 병합 표시
    - (src/app/board/_actions/listBoardPosts.ts, src/app/board/page.tsx, src/components/features/board/BoardListView.tsx).
- 목록 아이템 클릭 시 UUID가 아닌 mock id는 데모 게시글로 리다이렉트, UUID는 자신의 상세로 이동; BoardItem을 링크 대응 
   - (src/components/features/board/BoardListView.tsx, src/components/features/board/BoardItem.tsx).
- 상세 페이지가 Supabase에서 게시글을 읽어 렌더하고, 목록 복귀 시 컨텍스트(scope/board/dept) 유지 
   - (src/app/board/[postId]/page.tsx, src/components/features/board-post/BoardPostView.tsx, src/components/features/board-post/card/*).


## 🎯 관련 이슈
Closes #89 

## ✅ 체크리스트
- [ ]  글 작성 → /board/{postId} 리다이렉트 확인
- [ ] 목록에서 mock 아이템 클릭 → 데모 게시글 상세 진입 확인
- [ ] 목록에서 Supabase 글 클릭 → 해당 글 상세 표시 확인
- [ ] 상세의 “목록보기” → 이전 컨텍스트 포함 목록 복귀 확인

## 📸 스크린샷
