### PR TITLE
[Feat] 메인 페이지 게시판 위젯 구현 및 Today 갓생이 개선 #75

### DIFF
--- a/src/app/_actions/homeBoard.ts
+++ b/src/app/_actions/homeBoard.ts
@@ -1,0 +1,92 @@
+'use server';
+
+import { createServerSupabase } from '@/lib/supabase/server';
+import type { MainBoardPostSummary } from '@/types/home';
+
+/**
+ * 로그인 유저용: 모든 게시판(전사 + 부서)의 최신글
+ */
+export async function getMemberAllBoards(
+  limit: number = 6
+): Promise<MainBoardPostSummary[]> {
+  const supabase = await createServerSupabase();
+
+  const { data, error } = await supabase
+    .from('board_posts')
+    .select('id, scope, board, dept, title, created_at')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error || !data) {
+    console.error('[getMemberAllBoards] fetch failed', error);
+    return [];
+  }
+
+  return data.map(post => ({
+    id: post.id,
+    scope: post.scope as 'company' | 'department',
+    categoryName:
+      post.scope === 'company' ? post.board || '전사' : post.dept || '부서',
+    title: post.title,
+    createdAt: post.created_at,
+  }));
+}
+
+/**
+ * 게스트용: 전사게시판의 '공지사항' 카테고리 최신글
+ */
+export async function getGuestAnnouncements(
+  limit: number = 6
+): Promise<MainBoardPostSummary[]> {
+  const supabase = await createServerSupabase();
+
+  const { data, error } = await supabase
+    .from('board_posts')
+    .select('id, scope, board, title, created_at')
+    .eq('scope', 'company')
+    .eq('board', '공지사항')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error || !data) {
+    console.error('[getGuestAnnouncements] fetch failed', error);
+    return [];
+  }
+
+  return data.map(post => ({
+    id: post.id,
+    scope: 'company' as const,
+    categoryName: '공지사항',
+    title: post.title,
+    createdAt: post.created_at,
+  }));
+}
+
+/**
+ * 게스트용: 전사 + 부서 게시판의 모든 최신글
+ */
+export async function getGuestCommunity(
+  limit: number = 6
+): Promise<MainBoardPostSummary[]> {
+  const supabase = await createServerSupabase();
+
+  const { data, error } = await supabase
+    .from('board_posts')
+    .select('id, scope, board, dept, title, created_at')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error || !data) {
+    console.error('[getGuestCommunity] fetch failed', error);
+    return [];
+  }
+
+  return data.map(post => ({
+    id: post.id,
+    scope: post.scope as 'company' | 'department',
+    categoryName:
+      post.scope === 'company' ? post.board || '전사' : post.dept || '부서',
+    title: post.title,
+    createdAt: post.created_at,
+  }));
+}

--- a/src/app/_actions/todayRank.ts
+++ b/src/app/_actions/todayRank.ts
@@ -11,6 +11,7 @@ export type TodayRankOptions = {
 type TodayRankRow = {
   user_id: string;
   display_name: string | null;
+  rank: string | null;
   department_name: string | null;
   performance_rate: number | null;
   attendance_rate: number | null;
@@ -46,6 +47,7 @@ export async function getTodayRanks(
         (row: TodayRankRow): TodayRankUser => ({
           userId: row.user_id,
           displayName: (row.display_name ?? '익명 사원').trim() || '익명 사원',
+          rank: (row.rank ?? '사원').trim() || '사원',
           departmentName:
             (row.department_name ?? '부서 미정').trim() || '부서 미정',
           performanceRate: clampPercentage(row.performance_rate),

--- a/src/components/features/home/AnnouncementsWidget.tsx
+++ b/src/components/features/home/AnnouncementsWidget.tsx
@@ -1,0 +1,29 @@
+import { Icon } from '@iconify/react';
+import { BoardSummaryItem } from './BoardSummaryItem';
+import type { MainBoardPostSummary } from '@/types/home';
+
+type AnnouncementsWidgetProps = {
+  posts: MainBoardPostSummary[];
+};
+
+export function AnnouncementsWidget({ posts }: AnnouncementsWidgetProps) {
+  return (
+    <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[304px] flex flex-col gap-4">
+      <div className="flex items-center gap-1">
+        <Icon
+          icon="icon-park:message-emoji"
+          className="w-6 h-6 text-primary-500"
+        />
+        <h2 className="brand-h3 text-grey-900">공지사항</h2>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        {posts.length === 0 ? (
+          <p className="body-base text-grey-500">최신 공지사항이 없습니다.</p>
+        ) : (
+          posts.map(post => <BoardSummaryItem key={post.id} post={post} />)
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/features/home/BoardSummaryItem.tsx
+++ b/src/components/features/home/BoardSummaryItem.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+import { getRelativeTimeString } from '@/lib/dateUtils';
+import type { MainBoardPostSummary } from '@/types/home';
+
+type BoardSummaryItemProps = {
+  post: MainBoardPostSummary;
+};
+
+export function BoardSummaryItem({ post }: BoardSummaryItemProps) {
+  // 게시글 상세 페이지 URL 생성
+  const postUrl =
+    post.scope === 'company'
+      ? `/board/${post.id}?scope=company&board=${encodeURIComponent(post.categoryName)}`
+      : `/board/${post.id}?scope=department&dept=${encodeURIComponent(post.categoryName)}`;
+
+  return (
+    <Link
+      href={postUrl}
+      className="flex items-center justify-between gap-2 hover:bg-grey-50 transition-colors rounded px-1 py-1"
+    >
+      <span className="text-grey-500 text-base truncate flex-1">
+        {post.title}
+      </span>
+      <span className="text-grey-500 text-sm whitespace-nowrap flex-shrink-0 text-right min-w-[80px]">
+        {getRelativeTimeString(post.createdAt)}
+      </span>
+    </Link>
+  );
+}

--- a/src/components/features/home/BoardWidget.tsx
+++ b/src/components/features/home/BoardWidget.tsx
@@ -1,0 +1,29 @@
+import { Icon } from '@iconify/react';
+import { BoardSummaryItem } from './BoardSummaryItem';
+import type { MainBoardPostSummary } from '@/types/home';
+
+type BoardWidgetProps = {
+  posts: MainBoardPostSummary[];
+};
+
+export function BoardWidget({ posts }: BoardWidgetProps) {
+  return (
+    <section className="bg-grey-100 rounded-[5px] p-6 flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <Icon
+          icon="icon-park:message-emoji"
+          className="w-6 h-6 text-primary-500"
+        />
+        <h2 className="brand-h3 text-grey-900">게시판</h2>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {posts.length === 0 ? (
+          <p className="body-base text-grey-500">최신 글이 없습니다.</p>
+        ) : (
+          posts.map(post => <BoardSummaryItem key={post.id} post={post} />)
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/features/home/CommunityWidget.tsx
+++ b/src/components/features/home/CommunityWidget.tsx
@@ -1,0 +1,29 @@
+import { Icon } from '@iconify/react';
+import { BoardSummaryItem } from './BoardSummaryItem';
+import type { MainBoardPostSummary } from '@/types/home';
+
+type CommunityWidgetProps = {
+  posts: MainBoardPostSummary[];
+};
+
+export function CommunityWidget({ posts }: CommunityWidgetProps) {
+  return (
+    <section className="bg-grey-100 rounded-[5px] p-6 md:min-h-[304px] flex flex-col gap-4">
+      <div className="flex items-center gap-1">
+        <Icon
+          icon="icon-park:message-emoji"
+          className="w-6 h-6 text-primary-500"
+        />
+        <h2 className="brand-h3 text-grey-900">커뮤니티</h2>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        {posts.length === 0 ? (
+          <p className="body-base text-grey-500">최신 글이 없습니다.</p>
+        ) : (
+          posts.map(post => <BoardSummaryItem key={post.id} post={post} />)
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/features/home/TodayRankSection.tsx
+++ b/src/components/features/home/TodayRankSection.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { TodayRankWidget } from '@/components/home/TodayRankWidget';
+import { useTodayRanks } from '@/hooks/useTodayRanks';
+
+/**
+ * TodayRankWidget을 위한 Client Component Wrapper
+ * useTodayRanks 훅을 사용하여 데이터를 가져옴
+ */
+export function TodayRankSection() {
+  const {
+    ranks: todayRanks,
+    isLoading: isTodayRanksLoading,
+    isError: isTodayRanksError,
+  } = useTodayRanks();
+
+  return (
+    <TodayRankWidget
+      ranks={todayRanks}
+      isLoading={isTodayRanksLoading}
+      isError={isTodayRanksError}
+    />
+  );
+}

--- a/src/components/home/TodayRankWidget.tsx
+++ b/src/components/home/TodayRankWidget.tsx
@@ -56,34 +56,34 @@ export function TodayRankWidget({
       {topRanks.map((user, index) => {
         const safePerf = clampPercentage(user.performanceRate);
         const safeAttend = clampPercentage(user.attendanceRate);
+        // 성만 추출 (공백 기준 첫 단어, 1-2글자 성씨 지원)
+        const lastName =
+          user.displayName.split(' ')[0] || user.displayName.charAt(0);
 
         return (
-          <li
-            key={user.userId}
-            className="grid grid-cols-[minmax(84px,1fr)_83px_83px] items-center gap-2 sm:grid-cols-[122px_83px_83px] sm:gap-4 md:gap-6"
-          >
-            <div className="flex items-center gap-2 min-w-0 w-full overflow-hidden sm:w-[122px]">
+          <li key={user.userId} className="grid grid-cols-3 items-center gap-6">
+            <div className="flex items-center gap-2 min-w-0 justify-self-start">
               <span className="brand-h4 text-primary-500 flex-shrink-0">
                 {String(index + 1).padStart(2, '0')}
               </span>
-              <span className="body-sm text-grey-900 font-semibold truncate whitespace-nowrap">
-                {user.displayName}
+              <span className="body-sm text-grey-900 font-semibold whitespace-nowrap">
+                {lastName} {user.rank}
               </span>
               <span className="body-xs text-grey-500 flex-shrink-0 whitespace-nowrap">
                 {user.departmentName}
               </span>
             </div>
-            <div className="flex items-center gap-1.5 body-sm w-[83px]">
+            <div className="flex items-center gap-2 body-sm whitespace-nowrap justify-self-start">
               <Icon
                 icon="icon-park-solid:up-two"
-                className="w-4 h-4 text-primary-500"
+                className="w-4 h-4 text-primary-500 flex-shrink-0"
               />
               <span className="body-sm text-grey-500">성과 {safePerf}%</span>
             </div>
-            <div className="flex items-center gap-1.5 body-sm w-[83px]">
+            <div className="flex items-center gap-2 body-sm whitespace-nowrap justify-self-start">
               <Icon
                 icon="fluent:flash-on-24-filled"
-                className="w-4 h-4 text-primary-500"
+                className="w-4 h-4 text-primary-500 flex-shrink-0"
               />
               <span className="body-sm text-grey-500">근태 {safeAttend}%</span>
             </div>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { ButtonHTMLAttributes, ReactNode, MouseEvent } from 'react';
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,0 +1,42 @@
+/**
+ * 상대 시간 포맷 (예: "방금 전", "5분 전", "1시간 전")
+ */
+export function getRelativeTimeString(dateString: string): string {
+  const now = new Date();
+  const date = new Date(dateString);
+  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+
+  if (diffInSeconds < 60) {
+    return '방금 전';
+  }
+
+  const diffInMinutes = Math.floor(diffInSeconds / 60);
+  if (diffInMinutes < 60) {
+    return `${diffInMinutes}분 전`;
+  }
+
+  const diffInHours = Math.floor(diffInMinutes / 60);
+  if (diffInHours < 24) {
+    return `${diffInHours}시간 전`;
+  }
+
+  const diffInDays = Math.floor(diffInHours / 24);
+  if (diffInDays < 7) {
+    return `${diffInDays}일 전`;
+  }
+
+  // 7일 이상은 날짜 포맷으로 표시
+  return formatDate(dateString);
+}
+
+/**
+ * YYYY.MM.DD 포맷
+ */
+export function formatDate(dateString: string): string {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}.${month}.${day}`;
+}

--- a/src/types/home.ts
+++ b/src/types/home.ts
@@ -1,0 +1,12 @@
+import type { BoardScope } from '@/constants/board';
+
+/**
+ * 메인 페이지 게시판 위젯용 게시글 요약 타입
+ */
+export type MainBoardPostSummary = {
+  id: string;
+  scope: BoardScope;
+  categoryName: string; // 게시판 이름 (예: '공지사항', 'IT부')
+  title: string;
+  createdAt: string; // ISO 8601 형식
+};

--- a/src/types/todayRank.ts
+++ b/src/types/todayRank.ts
@@ -1,6 +1,7 @@
 export type TodayRankUser = {
   userId: string;
   displayName: string;
+  rank: string;
   departmentName: string;
   performanceRate: number;
   attendanceRate: number;

--- a/supabase-executive-setup.sql
+++ b/supabase-executive-setup.sql
@@ -1,0 +1,51 @@
+-- ============================================================================
+-- 임원진(Executive) 시스템 구축
+-- ============================================================================
+-- 목적: 일반 회원과 구분되는 임원진 전용 직함 관리
+--       (갓끼 CEO, 갓냥 COO, 갓햄 CTO)
+-- ============================================================================
+
+-- 1. profiles 테이블에 executive_title 컬럼 추가
+ALTER TABLE public.profiles
+ADD COLUMN IF NOT EXISTS executive_title TEXT NULL;
+
+-- 2. executive_title에 코멘트 추가
+COMMENT ON COLUMN public.profiles.executive_title IS
+'임원진 전용 직함 (CEO, COO, CTO 등). NULL이면 일반 회원.';
+
+-- 3. 임원진 설정
+-- 갓끼 CEO
+UPDATE public.profiles
+SET executive_title = 'CEO'
+WHERE last_name LIKE '%갓끼%'
+   OR first_name LIKE '%갓끼%'
+   OR email ILIKE '%godkki%'
+   OR email ILIKE '%gatkki%';
+
+-- 갓냥 COO
+UPDATE public.profiles
+SET executive_title = 'COO'
+WHERE last_name LIKE '%갓냥%'
+   OR first_name LIKE '%갓냥%'
+   OR email ILIKE '%godnyang%'
+   OR email ILIKE '%gatnyang%';
+
+-- 갓햄 CTO
+UPDATE public.profiles
+SET executive_title = 'CTO'
+WHERE last_name LIKE '%갓햄%'
+   OR first_name LIKE '%갓햄%'
+   OR email ILIKE '%godham%'
+   OR email ILIKE '%gatham%';
+
+-- 4. 확인용 쿼리
+SELECT
+  id,
+  email,
+  last_name,
+  first_name,
+  rank,
+  executive_title,
+  department
+FROM public.profiles
+WHERE executive_title IS NOT NULL;


### PR DESCRIPTION
## 📋 작업 내용
메인 페이지에 게시판 위젯을 추가하고 로그인/게스트 상태에 따라 다른 레이아웃을 표시하도록 구현. 추가로 Today 갓생이 위젯을 개선하고 임원진 시스템을 구축

## 🎯 관련 이슈
Closes #75 

 ## ✨ 주요 변경사항
  ### 1. 메인 페이지 게시판 위젯 구현
  #### 📂 새로운 파일
  - `src/types/home.ts` - 메인 페이지용 게시글 타입 정의
  - `src/app/_actions/homeBoard.ts` - 서버 액션 (게시판 데이터 가져오기)
  - `src/lib/dateUtils.ts` - 날짜 포맷 유틸리티 (상대 시간 표시)
  - `src/components/features/home/BoardSummaryItem.tsx` - 게시글 아이템 컴포넌트
  - `src/components/features/home/BoardWidget.tsx` - 로그인 유저용 게시판 위젯
  - `src/components/features/home/AnnouncementsWidget.tsx` - 게스트용 공지사항 위젯
  - `src/components/features/home/CommunityWidget.tsx` - 게스트용 커뮤니티 위젯
  - `src/components/features/home/TodayRankSection.tsx` - Today 갓생이 wrapper 컴포넌트

  #### 🔧 수정된 파일
  - `src/app/page.tsx` - 메인 페이지 레이아웃 재구성
    - 로그인 유저: 2컬럼 3row (근태+사원정보 / 게시판+성과현황 / 임원진+Today갓생이)
    - 게스트: 배너(전체폭) + 2컬럼 2row (공지+커뮤니티 / 임원진+Today갓생이)
  - `src/components/ui/Button.tsx` - 'use client' 추가 (onClick 핸들러 지원)

  #### 📊 데이터 흐름
  - **로그인 유저**: 전체 게시판(전사+부서)의 최신글 6개
  - **게스트**: 공지사항 최신 6개 + 커뮤니티 최신 6개

  ---

  ### 2. Today 갓생이 위젯 개선
  #### 🎯 레이아웃 개선
  - 3컬럼 그리드를 왼쪽 정렬로 변경 (`justify-self-start`)
  - gap을 24px로 통일
  - 아이콘 크기 고정 및 줄바꿈 방지

  #### 👤 이름 표시 개선
  - 성(1-2글자) + 직급 + 부서명 형식
  - 예: "강 인턴 IT부", "황보 대리 취업부"
  - 공백 기준으로 성을 추출하여 2글자 성씨 지원

  #### 🔧 데이터 구조 변경
  - `TodayRankUser` 타입에 `rank` 필드 추가
  - `getTodayRanks` 액션에서 rank 정보 가져오도록 수정

  ---

  ### 3. 임원진 시스템 구축
  #### 📂 새로운 파일
  - `supabase-executive-setup.sql` - 임원진 시스템 구축 SQL

  #### 🎖️ 임원진 전용 직함
  - `executive_title` 컬럼 추가 (CEO, COO, CTO)
  - 갓끼 CEO, 갓냥 COO, 갓햄 CTO 설정

  #### ⚖️ Today 갓생이에서 임원진 제외
  - `get_today_ranks` RPC 함수에 `WHERE executive_title IS NULL` 조건 추가
  - 일반 회원만 Today 갓생이 선정 (공정성 확보)

  ---

  ## 🎨 UI/UX 개선
  - 게스트 메인 화면: 배너(전체폭) → 2열 위젯 구조로 깔끔하게 정리
  - 로그인 메인 화면: 2컬럼 3row 구조로 통일성 확보
  - 모든 위젯에서 "더보기" 버튼 제거 (심플한 디자인)
  - 게시판 위젯 최소 높이 설정 (`md:min-h-[304px]`)

  ---

  ## 🔍 기술적 개선
  - Server Component로 데이터 fetching (초기 로딩 성능 개선)
  - 상대 시간 표시로 UX 향상 ("방금 전", "5분 전", "1시간 전")
  - enum 타입 처리 개선 (`rank::text` 캐스팅)
  - 게시글 상세 URL 수정 (query parameter 방식)

  ---

  ## 🧪 테스트 시나리오
  - [x] 로그인 상태에서 게시판 위젯에 최신글 표시 확인
  - [x] 게스트 상태에서 공지사항/커뮤니티 위젯 표시 확인
  - [x] 게시글 클릭 시 상세 페이지 이동 확인
  - [x] Today 갓생이에 임원진 제외 확인
  - [x] 모바일/데스크탑 반응형 레이아웃 확인

  ---

  ## 📦 실행 필요한 SQL
  ```bash
  # 1. 임원진 시스템 구축
  supabase-executive-setup.sql

  # 2. Today 갓생이 RPC 함수 업데이트
  supabase-today-rank-rpc.sql

  ---
  🎉 결과

  - 메인 페이지가 로그인/게스트 상태에 맞춰 최적화된 정보를 제공
  - Today 갓생이가 더 공정하고 깔끔하게 개선
  - 임원진 시스템으로 특별한 직함 관리 가능
