### PR TITLE
[Feat] 업무계획 페이지 Timer 카드 UI 퍼블리싱

### DIFF
--- a/src/components/features/task-plan/PomodoroTimerCard.tsx
+++ b/src/components/features/task-plan/PomodoroTimerCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { Icon } from '@iconify/react';
 import Button from '@/components/ui/Button';
 import Toast from '@/components/ui/Toast';
@@ -29,18 +29,19 @@ function formatTotalFocus(seconds: number) {
 interface PomodoroTimerCardProps {
   onFocusDone?: (durationSeconds: number) => void;
   onFocusFail?: (elapsedSeconds: number) => void;
-  onBreakStart?: (durationSeconds: number) => void;
+  onBreakRecorded?: (elapsedSeconds: number) => void;
 }
 
 export default function PomodoroTimerCard({
   onFocusDone,
   onFocusFail,
-  onBreakStart,
+  onBreakRecorded,
 }: PomodoroTimerCardProps = {}) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
 
-  // ref로 preset 값 캡처 — onFocusComplete 콜백 클로저에서 최신 값 참조
+  const dismissToast = useCallback(() => setToastMessage(null), []);
+  const closeDrawer = useCallback(() => setIsDrawerOpen(false), []);
   const focusPresetRef = useRef(30);
 
   const {
@@ -63,7 +64,7 @@ export default function PomodoroTimerCard({
     },
     onBreakComplete: () => setToastMessage('잘 쉬었나요? 다시 힘차게 달려요✊'),
     onFocusFail,
-    onBreakStart,
+    onBreakRecorded,
   });
 
   focusPresetRef.current = focusPresetMinutes;
@@ -71,6 +72,15 @@ export default function PomodoroTimerCard({
   const totalFocus = useMemo(
     () => formatTotalFocus(totalFocusSeconds),
     [totalFocusSeconds]
+  );
+
+  const handleSaveSettings = useCallback(
+    (settings: { focusPresetMinutes: number; breakPresetMinutes: number }) => {
+      setFocusPresetMinutes(settings.focusPresetMinutes);
+      setBreakPresetMinutes(settings.breakPresetMinutes);
+      setToastMessage('타이머 설정을 저장했어요.');
+    },
+    [setBreakPresetMinutes, setFocusPresetMinutes]
   );
 
   return (
@@ -87,7 +97,7 @@ export default function PomodoroTimerCard({
           </div>
           <button
             type="button"
-            className="p-1 rounded-full hover:bg-grey-200 transition-colors"
+            className="p-1 rounded-full transition-colors hover:bg-grey-200"
             aria-label="타이머 설정 열기"
             onClick={() => setIsDrawerOpen(true)}
           >
@@ -98,11 +108,11 @@ export default function PomodoroTimerCard({
           </button>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <div className="flex flex-col gap-1">
-            <span className="body-sm text-grey-500 font-semibold">Timer</span>
+            <span className="body-sm font-semibold text-grey-500">Timer</span>
             <div className="inline-flex items-end gap-1">
-              <span className="brand-h1 text-primary-500 tabular-nums">
+              <span className="brand-h1 tabular-nums text-primary-500">
                 {formatTime(remainingSeconds)}
               </span>
               <span className="body-xs text-grey-500">
@@ -112,15 +122,15 @@ export default function PomodoroTimerCard({
           </div>
 
           <div className="flex flex-col gap-1">
-            <span className="body-sm text-grey-500 font-semibold">
+            <span className="body-sm font-semibold text-grey-500">
               총 집중시간
             </span>
             <div className="inline-flex items-end gap-1">
-              <span className="brand-h1 text-primary-500 tabular-nums">
+              <span className="brand-h1 tabular-nums text-primary-500">
                 {totalFocus.hours}
               </span>
               <span className="body-xs text-grey-500">시간</span>
-              <span className="brand-h1 text-primary-500 tabular-nums">
+              <span className="brand-h1 tabular-nums text-primary-500">
                 {totalFocus.minutes}
               </span>
               <span className="body-xs text-grey-500">분</span>
@@ -130,7 +140,7 @@ export default function PomodoroTimerCard({
 
         <div className="grid grid-cols-2 gap-3">
           <Button variant="secondary" fullWidth onClick={toggleRunning}>
-            {isRunning ? '일시정지' : '재시작'}
+            {isRunning ? '일시정지' : '시작'}
           </Button>
           <Button variant="text" fullWidth onClick={startBreak}>
             휴식하기
@@ -140,14 +150,14 @@ export default function PomodoroTimerCard({
 
       <BottomSheet
         open={isDrawerOpen}
-        onClose={() => setIsDrawerOpen(false)}
+        onClose={closeDrawer}
         title="타이머 설정"
       >
         <TimerSettingContent
           focusPresetMinutes={focusPresetMinutes}
           breakPresetMinutes={breakPresetMinutes}
-          setFocusPresetMinutes={setFocusPresetMinutes}
-          setBreakPresetMinutes={setBreakPresetMinutes}
+          onSave={handleSaveSettings}
+          onClose={closeDrawer}
         />
       </BottomSheet>
 
@@ -155,7 +165,7 @@ export default function PomodoroTimerCard({
         show={!!toastMessage}
         message={toastMessage ?? ''}
         type="success"
-        onClose={() => setToastMessage(null)}
+        onClose={dismissToast}
       />
     </>
   );

--- a/src/components/features/task-plan/TimerCard.tsx
+++ b/src/components/features/task-plan/TimerCard.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import { Icon } from '@iconify/react';
+import BottomSheet from '@/components/ui/BottomSheet';
+import TimerSettingContent from './TimerSettingContent';
+import type { TimerMode, TimerSettings } from './types';
+
+function formatTime(seconds: number) {
+  const safeSeconds = Math.max(0, seconds);
+  const minutes = Math.floor(safeSeconds / 60);
+  const remainingSeconds = safeSeconds % 60;
+
+  return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
+}
+
+function formatTotalFocus(seconds: number) {
+  const safeSeconds = Math.max(0, seconds);
+  const totalMinutes = Math.floor(safeSeconds / 60);
+
+  return {
+    hours: Math.floor(totalMinutes / 60),
+    minutes: totalMinutes % 60,
+  };
+}
+
+type ConfirmAction = 'skip' | 'end' | null;
+
+interface ControlIconButtonProps {
+  tooltip: string;
+  ariaLabel: string;
+  icon: string;
+  onClick: () => void;
+}
+
+function ControlIconButton({
+  tooltip,
+  ariaLabel,
+  icon,
+  onClick,
+}: ControlIconButtonProps) {
+  return (
+    <div className="group relative flex">
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        onClick={onClick}
+        className="text-fixed-grey-200 transition-colors hover:text-fixed-white"
+      >
+        <Icon icon={icon} className="h-5 w-5" />
+      </button>
+      <div className="pointer-events-none absolute left-1/2 top-0 z-20 -translate-x-1/2 -translate-y-[calc(100%+8px)] opacity-0 transition-all duration-200 ease-out group-hover:-translate-y-[calc(100%+12px)] group-hover:opacity-100 group-focus-within:-translate-y-[calc(100%+12px)] group-focus-within:opacity-100">
+        <div className="whitespace-nowrap rounded-[6px] bg-fixed-grey-900 px-2 py-1 text-12 font-medium text-fixed-white shadow-lg">
+          {tooltip}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface TimerCardProps {
+  mode: TimerMode;
+  isRunning: boolean;
+  remainingSeconds: number;
+  totalFocusSeconds: number;
+  focusPresetMinutes: number;
+  breakPresetMinutes: number;
+  routineName?: string;
+  nextRoutineName?: string;
+  onToggleRunning: () => void;
+  onSkip: () => void;
+  onReset: () => void;
+  onEnd: () => void;
+  onSaveSettings: (settings: TimerSettings) => void;
+}
+
+export default function TimerCard({
+  mode,
+  isRunning,
+  remainingSeconds,
+  totalFocusSeconds,
+  focusPresetMinutes,
+  breakPresetMinutes,
+  routineName,
+  nextRoutineName,
+  onToggleRunning,
+  onSkip,
+  onReset,
+  onEnd,
+  onSaveSettings,
+}: TimerCardProps) {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction>(null);
+
+  const totalFocus = useMemo(
+    () => formatTotalFocus(totalFocusSeconds),
+    [totalFocusSeconds]
+  );
+
+  const sessionLabel =
+    routineName ?? (mode === 'focus' ? '집중 중' : '휴식 중');
+  const skipTargetLabel =
+    mode === 'focus' ? (nextRoutineName ?? '휴식 시간') : '다음 단계';
+  const confirmTitle =
+    confirmAction === 'skip' ? '다음 단계로 넘어갈까요?' : '세션 종료';
+  const confirmDescription =
+    confirmAction === 'skip'
+      ? `'${skipTargetLabel}'으로 넘어가면 현재 기록이 중단됩니다.`
+      : '세션을 종료하면 진행 중인 기록이 중단됩니다.';
+
+  const closeConfirm = useCallback(() => setConfirmAction(null), []);
+  const closeDrawer = useCallback(() => setIsDrawerOpen(false), []);
+
+  const handleConfirmAction = useCallback(() => {
+    if (confirmAction === 'skip') {
+      onSkip();
+    }
+
+    if (confirmAction === 'end') {
+      onEnd();
+    }
+
+    closeConfirm();
+  }, [closeConfirm, confirmAction, onEnd, onSkip]);
+
+  return (
+    <>
+      <section className="flex flex-col gap-5 rounded-[5px] bg-grey-100 p-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1">
+            <Icon
+              icon="icon-park:tomato"
+              className="h-6 w-6 icon-dark-invert"
+              aria-hidden="true"
+            />
+            <h2 className="brand-h3 text-grey-900">Timer</h2>
+          </div>
+          <button
+            type="button"
+            className="rounded-full p-1 transition-colors hover:bg-grey-200"
+            aria-label="타이머 설정 열기"
+            onClick={() => setIsDrawerOpen(true)}
+          >
+            <Icon
+              icon="icon-park:more-one"
+              className="h-6 w-6 icon-dark-invert"
+            />
+          </button>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div className="flex flex-col gap-1">
+            <span className="body-sm font-semibold text-grey-500">Timer</span>
+            <div className="inline-flex items-end gap-1">
+              <span className="brand-h1 tabular-nums text-primary-500">
+                {formatTime(remainingSeconds)}
+              </span>
+              <span className="body-xs text-grey-500">
+                {mode === 'focus' ? '남은 집중시간' : '남은 휴식시간'}
+              </span>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <span className="body-sm font-semibold text-grey-500">
+              총 집중시간
+            </span>
+            <div className="inline-flex items-end gap-1">
+              <span className="brand-h1 tabular-nums text-primary-500">
+                {totalFocus.hours}
+              </span>
+              <span className="body-xs text-grey-500">시간</span>
+              <span className="brand-h1 tabular-nums text-primary-500">
+                {totalFocus.minutes}
+              </span>
+              <span className="body-xs text-grey-500">분</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between rounded-[5px] bg-fixed-grey-900 px-4 py-3">
+          <span className="body-sm mr-3 truncate font-semibold text-fixed-white">
+            {sessionLabel}
+          </span>
+          <div className="flex flex-shrink-0 items-center gap-3">
+            <ControlIconButton
+              tooltip={isRunning ? '타이머 일시정지' : '타이머 시작'}
+              ariaLabel={isRunning ? '일시정지' : '시작'}
+              icon={
+                isRunning
+                  ? 'material-symbols:pause-rounded'
+                  : 'material-symbols:play-arrow-rounded'
+              }
+              onClick={onToggleRunning}
+            />
+            <ControlIconButton
+              tooltip={
+                mode === 'focus' ? '다음 단계로 이동' : '다음 단계로 넘어가기'
+              }
+              ariaLabel={
+                mode === 'focus' ? '다음 단계로 이동' : '다음 단계로 넘어가기'
+              }
+              icon="material-symbols:skip-next-rounded"
+              onClick={() => setConfirmAction('skip')}
+            />
+            <ControlIconButton
+              tooltip="타이머 다시 시작"
+              ariaLabel="타이머 초기화"
+              icon="material-symbols:refresh-rounded"
+              onClick={onReset}
+            />
+            <ControlIconButton
+              tooltip="현재 세션 종료"
+              ariaLabel="세션 종료"
+              icon="material-symbols:cancel-rounded"
+              onClick={() => setConfirmAction('end')}
+            />
+          </div>
+        </div>
+      </section>
+
+      <BottomSheet
+        open={isDrawerOpen}
+        onClose={closeDrawer}
+        title="타이머 설정"
+      >
+        <TimerSettingContent
+          focusPresetMinutes={focusPresetMinutes}
+          breakPresetMinutes={breakPresetMinutes}
+          onSave={onSaveSettings}
+          onClose={closeDrawer}
+        />
+      </BottomSheet>
+
+      <BottomSheet
+        open={confirmAction !== null}
+        onClose={closeConfirm}
+        title={confirmTitle}
+      >
+        <div className="flex flex-col gap-4">
+          <p className="text-14 text-grey-700">{confirmDescription}</p>
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              className="w-full rounded-[8px] bg-primary-500 px-4 py-2 text-14 font-medium text-fixed-white"
+              onClick={handleConfirmAction}
+            >
+              확인
+            </button>
+            <button
+              type="button"
+              className="w-full rounded-[8px] border border-dark bg-dark px-4 py-2 text-14 font-medium text-dark"
+              onClick={closeConfirm}
+            >
+              취소
+            </button>
+          </div>
+        </div>
+      </BottomSheet>
+    </>
+  );
+}

--- a/src/components/features/task-plan/TimerSettingContent.tsx
+++ b/src/components/features/task-plan/TimerSettingContent.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useState } from 'react';
 import Select from '@/components/ui/Select';
 
 const FOCUS_PRESETS = [30, 45, 60];
@@ -6,16 +9,32 @@ const BREAK_PRESETS = [15, 20, 25, 30, 60];
 interface TimerSettingContentProps {
   focusPresetMinutes: number;
   breakPresetMinutes: number;
-  setFocusPresetMinutes: (minutes: number) => void;
-  setBreakPresetMinutes: (minutes: number) => void;
+  onSave: (settings: {
+    focusPresetMinutes: number;
+    breakPresetMinutes: number;
+  }) => void;
+  onClose: () => void;
 }
 
 export default function TimerSettingContent({
   focusPresetMinutes,
   breakPresetMinutes,
-  setFocusPresetMinutes,
-  setBreakPresetMinutes,
+  onSave,
+  onClose,
 }: TimerSettingContentProps) {
+  const [nextFocusPresetMinutes, setNextFocusPresetMinutes] =
+    useState(focusPresetMinutes);
+  const [nextBreakPresetMinutes, setNextBreakPresetMinutes] =
+    useState(breakPresetMinutes);
+
+  const handleSave = () => {
+    onSave({
+      focusPresetMinutes: nextFocusPresetMinutes,
+      breakPresetMinutes: nextBreakPresetMinutes,
+    });
+    onClose();
+  };
+
   return (
     <div className="flex flex-col gap-5">
       <div className="flex flex-col gap-2">
@@ -24,14 +43,14 @@ export default function TimerSettingContent({
           {FOCUS_PRESETS.map(preset => (
             <label
               key={preset}
-              className="flex items-center gap-2 px-3 py-2 rounded-[5px] border border-dark bg-dark cursor-pointer"
+              className="flex cursor-pointer items-center gap-2 rounded-[5px] border border-dark bg-dark px-3 py-2"
             >
               <input
                 type="radio"
                 name="focusPreset"
                 value={preset}
-                checked={focusPresetMinutes === preset}
-                onChange={() => setFocusPresetMinutes(preset)}
+                checked={nextFocusPresetMinutes === preset}
+                onChange={() => setNextFocusPresetMinutes(preset)}
                 className="accent-primary-500"
               />
               <span className="body-sm text-grey-900">{preset}분</span>
@@ -42,13 +61,30 @@ export default function TimerSettingContent({
 
       <Select
         label="휴식 프리셋"
-        value={String(breakPresetMinutes)}
-        onChange={value => setBreakPresetMinutes(Number(value))}
+        value={String(nextBreakPresetMinutes)}
+        onChange={value => setNextBreakPresetMinutes(Number(value))}
         options={BREAK_PRESETS.map(preset => ({
           value: String(preset),
           label: `${preset}분`,
         }))}
       />
+
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          className="w-full px-4 py-2 bg-primary-500 rounded-[8px] text-14 font-medium text-fixed-white"
+          onClick={handleSave}
+        >
+          저장
+        </button>
+        <button
+          type="button"
+          className="w-full px-4 py-2 bg-dark border border-dark rounded-[8px] text-14 font-medium text-dark"
+          onClick={onClose}
+        >
+          취소
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/features/task-plan/WorkPlanTimerSection.tsx
+++ b/src/components/features/task-plan/WorkPlanTimerSection.tsx
@@ -1,36 +1,166 @@
 'use client';
 
-import { useState } from 'react';
-import PomodoroTimerCard from './PomodoroTimerCard';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import TimerCard from './TimerCard';
 import TimelineCard from './TimelineCard';
+import Toast from '@/components/ui/Toast';
+import { usePomodoroTimer } from '@/hooks/usePomodoroTimer';
 import { PomodoroSession } from '@/types/pomodoro';
+import type { TimerSettings } from './types';
+
+interface ToastState {
+  message: string;
+  type: 'success' | 'info' | 'warning';
+}
+
+function sendWindowNotification(title: string, body: string) {
+  if (typeof window === 'undefined' || !('Notification' in window)) return;
+
+  if (Notification.permission === 'granted') {
+    new Notification(title, { body, icon: '/favicon.ico' });
+  }
+}
 
 export default function WorkPlanTimerSection() {
   const [sessions, setSessions] = useState<PomodoroSession[]>([]);
+  const [toast, setToast] = useState<ToastState | null>(null);
 
-  const addSession = (
-    status: PomodoroSession['status'],
-    durationSeconds: number
-  ) => {
-    setSessions(prev => [
-      ...prev,
-      {
-        id: crypto.randomUUID(),
-        status,
-        durationSeconds,
-        startedAt: new Date(),
-      },
-    ]);
-  };
+  const focusPresetRef = useRef(30);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && 'Notification' in window) {
+      if (Notification.permission === 'default') {
+        Notification.requestPermission();
+      }
+    }
+  }, []);
+
+  const showToast = useCallback(
+    (message: string, type: ToastState['type'] = 'success') => {
+      setToast({ message, type });
+    },
+    []
+  );
+
+  const dismissToast = useCallback(() => setToast(null), []);
+
+  const addSession = useCallback(
+    (status: PomodoroSession['status'], durationSeconds: number) => {
+      setSessions(prev => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          status,
+          durationSeconds,
+          startedAt: new Date(),
+        },
+      ]);
+    },
+    []
+  );
+
+  const {
+    mode,
+    isRunning,
+    remainingSeconds,
+    totalFocusSeconds,
+    focusPresetMinutes,
+    breakPresetMinutes,
+    setFocusPresetMinutes,
+    setBreakPresetMinutes,
+    toggleRunning,
+    startBreak,
+    skipToFocus,
+    resetTimer,
+    endSession,
+  } = usePomodoroTimer({
+    initialFocusMinutes: 30,
+    initialBreakMinutes: 15,
+    autoStart: false,
+    onFocusComplete: () => {
+      addSession('focus-done', focusPresetRef.current * 60);
+      showToast('집중이 완료됐어요. 다음 흐름을 이어가세요.', 'success');
+      sendWindowNotification(
+        '집중 완료',
+        '설정한 집중 시간이 끝났어요. 다음 작업을 이어갈 수 있어요.'
+      );
+    },
+    onBreakComplete: () => {
+      showToast('휴식이 끝났어요. 다시 집중을 시작할 수 있어요.', 'info');
+      sendWindowNotification(
+        '휴식 종료',
+        '휴식 시간이 끝났어요. 다시 집중을 시작할 수 있어요.'
+      );
+    },
+    onFocusFail: elapsed => addSession('focus-incomplete', elapsed),
+    onBreakRecorded: elapsed => addSession('break', elapsed),
+  });
+
+  focusPresetRef.current = focusPresetMinutes;
+
+  const handleToggleRunning = useCallback(() => {
+    toggleRunning();
+    showToast(
+      isRunning ? '타이머가 멈췄어요🐢' : '타이머 시작! 집중해서 끝내봐요🍀',
+      isRunning ? 'info' : 'success'
+    );
+  }, [isRunning, showToast, toggleRunning]);
+
+  const handleSkip = useCallback(() => {
+    if (mode === 'focus') {
+      startBreak();
+      showToast('휴식 시간으로 넘어갔어요.', 'info');
+      return;
+    }
+
+    skipToFocus();
+    showToast("'다음 작업'을 시작하려면 재생버튼을 눌러주세요.", 'info');
+  }, [mode, showToast, skipToFocus, startBreak]);
+
+  const handleReset = useCallback(() => {
+    resetTimer();
+    showToast('현재 타이머를 초기화했어요.', 'info');
+  }, [resetTimer, showToast]);
+
+  const handleEnd = useCallback(() => {
+    endSession();
+    showToast('현재 세션을 종료했어요.', 'success');
+  }, [endSession, showToast]);
+
+  const handleSaveSettings = useCallback(
+    (settings: TimerSettings) => {
+      setFocusPresetMinutes(settings.focusPresetMinutes);
+      setBreakPresetMinutes(settings.breakPresetMinutes);
+      showToast('타이머 설정을 저장했어요.', 'success');
+    },
+    [setBreakPresetMinutes, setFocusPresetMinutes, showToast]
+  );
 
   return (
-    <section className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-stretch">
-      <PomodoroTimerCard
-        onFocusDone={d => addSession('focus-done', d)}
-        onFocusFail={d => addSession('focus-incomplete', d)}
-        onBreakStart={d => addSession('break', d)}
+    <>
+      <section className="grid grid-cols-1 items-stretch gap-6 lg:grid-cols-2">
+        <TimerCard
+          mode={mode}
+          isRunning={isRunning}
+          remainingSeconds={remainingSeconds}
+          totalFocusSeconds={totalFocusSeconds}
+          focusPresetMinutes={focusPresetMinutes}
+          breakPresetMinutes={breakPresetMinutes}
+          onToggleRunning={handleToggleRunning}
+          onSkip={handleSkip}
+          onReset={handleReset}
+          onEnd={handleEnd}
+          onSaveSettings={handleSaveSettings}
+        />
+        <TimelineCard sessions={sessions} />
+      </section>
+
+      <Toast
+        show={!!toast}
+        message={toast?.message ?? ''}
+        type={toast?.type ?? 'success'}
+        onClose={dismissToast}
       />
-      <TimelineCard sessions={sessions} />
-    </section>
+    </>
   );
 }

--- a/src/components/features/task-plan/types.ts
+++ b/src/components/features/task-plan/types.ts
@@ -1,0 +1,6 @@
+export type TimerMode = 'focus' | 'break';
+
+export interface TimerSettings {
+  focusPresetMinutes: number;
+  breakPresetMinutes: number;
+}

--- a/src/hooks/usePomodoroTimer.ts
+++ b/src/hooks/usePomodoroTimer.ts
@@ -12,7 +12,7 @@ interface PomodoroTimerOptions {
   onFocusComplete?: () => void;
   onBreakComplete?: () => void;
   onFocusFail?: (elapsedSeconds: number) => void;
-  onBreakStart?: (durationSeconds: number) => void;
+  onBreakRecorded?: (elapsedSeconds: number) => void;
 }
 
 interface PomodoroTimerResult {
@@ -26,7 +26,12 @@ interface PomodoroTimerResult {
   setBreakPresetMinutes: (minutes: number) => void;
   toggleRunning: () => void;
   startBreak: () => void;
+  skipToFocus: () => void;
+  resetTimer: () => void;
+  endSession: () => void;
 }
+
+const MIN_ELAPSED_FOR_STAMP = 60;
 
 export function usePomodoroTimer(
   options: PomodoroTimerOptions = {}
@@ -39,7 +44,7 @@ export function usePomodoroTimer(
     onFocusComplete,
     onBreakComplete,
     onFocusFail,
-    onBreakStart,
+    onBreakRecorded,
   } = options;
 
   const [mode, setMode] = useState<PomodoroMode>('focus');
@@ -52,7 +57,20 @@ export function usePomodoroTimer(
   );
   const [isRunning, setIsRunning] = useState(autoStart);
   const [totalFocusSeconds, setTotalFocusSeconds] = useState(0);
+
   const completionNotifiedRef = useRef(false);
+  const breakElapsedSecondsRef = useRef(0);
+
+  const getElapsedFocusSeconds = useCallback(() => {
+    return focusPresetMinutes * 60 - remainingSeconds;
+  }, [focusPresetMinutes, remainingSeconds]);
+
+  const flushBreakRecord = useCallback(() => {
+    if (breakElapsedSecondsRef.current <= 0) return;
+
+    onBreakRecorded?.(breakElapsedSecondsRef.current);
+    breakElapsedSecondsRef.current = 0;
+  }, [onBreakRecorded]);
 
   useEffect(() => {
     if (!isRunning) return;
@@ -63,6 +81,8 @@ export function usePomodoroTimer(
 
         if (mode === 'focus') {
           setTotalFocusSeconds(total => total + 1);
+        } else {
+          breakElapsedSecondsRef.current += 1;
         }
 
         return prev - 1;
@@ -73,33 +93,38 @@ export function usePomodoroTimer(
   }, [isRunning, mode]);
 
   useEffect(() => {
-    if (remainingSeconds === 0 && !completionNotifiedRef.current) {
-      completionNotifiedRef.current = true;
-      setIsRunning(false);
+    if (remainingSeconds !== 0 || completionNotifiedRef.current) return;
 
-      if (mode === 'focus') {
-        onFocusComplete?.();
-      } else {
-        onBreakComplete?.();
+    completionNotifiedRef.current = true;
+    setIsRunning(false);
 
-        if (autoReturnToFocus) {
-          setMode('focus');
-          setRemainingSeconds(focusPresetMinutes * 60);
-        }
-      }
+    if (mode === 'focus') {
+      onFocusComplete?.();
+      return;
     }
 
+    flushBreakRecord();
+    onBreakComplete?.();
+
+    if (autoReturnToFocus) {
+      setMode('focus');
+      setRemainingSeconds(focusPresetMinutes * 60);
+    }
+  }, [
+    autoReturnToFocus,
+    flushBreakRecord,
+    focusPresetMinutes,
+    mode,
+    onBreakComplete,
+    onFocusComplete,
+    remainingSeconds,
+  ]);
+
+  useEffect(() => {
     if (remainingSeconds > 0) {
       completionNotifiedRef.current = false;
     }
-  }, [
-    remainingSeconds,
-    mode,
-    autoReturnToFocus,
-    focusPresetMinutes,
-    onFocusComplete,
-    onBreakComplete,
-  ]);
+  }, [remainingSeconds]);
 
   const setFocusPresetMinutes = useCallback(
     (minutes: number) => {
@@ -141,21 +166,74 @@ export function usePomodoroTimer(
 
   const startBreak = useCallback(() => {
     if (mode === 'break') return;
-    if (mode === 'focus' && remainingSeconds > 0) {
-      const elapsed = focusPresetMinutes * 60 - remainingSeconds;
-      if (elapsed > 0) onFocusFail?.(elapsed);
+
+    if (remainingSeconds > 0) {
+      const elapsed = getElapsedFocusSeconds();
+      if (elapsed >= MIN_ELAPSED_FOR_STAMP) {
+        onFocusFail?.(elapsed);
+      }
     }
-    onBreakStart?.(breakPresetMinutes * 60);
+
+    breakElapsedSecondsRef.current = 0;
+    completionNotifiedRef.current = false;
     setMode('break');
     setRemainingSeconds(breakPresetMinutes * 60);
     setIsRunning(true);
   }, [
-    mode,
-    remainingSeconds,
-    focusPresetMinutes,
     breakPresetMinutes,
+    getElapsedFocusSeconds,
+    mode,
     onFocusFail,
-    onBreakStart,
+    remainingSeconds,
+  ]);
+
+  const skipToFocus = useCallback(() => {
+    if (mode !== 'break') return;
+
+    setIsRunning(false);
+    flushBreakRecord();
+    completionNotifiedRef.current = false;
+    setMode('focus');
+    setRemainingSeconds(focusPresetMinutes * 60);
+  }, [flushBreakRecord, focusPresetMinutes, mode]);
+
+  const resetTimer = useCallback(() => {
+    setIsRunning(false);
+    completionNotifiedRef.current = false;
+
+    if (mode === 'focus') {
+      setRemainingSeconds(focusPresetMinutes * 60);
+      return;
+    }
+
+    setRemainingSeconds(breakPresetMinutes * 60);
+  }, [breakPresetMinutes, focusPresetMinutes, mode]);
+
+  const endSession = useCallback(() => {
+    if (mode === 'focus' && remainingSeconds > 0) {
+      const elapsed = getElapsedFocusSeconds();
+      if (elapsed >= MIN_ELAPSED_FOR_STAMP) {
+        onFocusFail?.(elapsed);
+      }
+    }
+
+    if (mode === 'break') {
+      flushBreakRecord();
+    }
+
+    setIsRunning(false);
+    completionNotifiedRef.current = false;
+    breakElapsedSecondsRef.current = 0;
+    setMode('focus');
+    setRemainingSeconds(focusPresetMinutes * 60);
+    setTotalFocusSeconds(0);
+  }, [
+    flushBreakRecord,
+    focusPresetMinutes,
+    getElapsedFocusSeconds,
+    mode,
+    onFocusFail,
+    remainingSeconds,
   ]);
 
   return {
@@ -169,5 +247,8 @@ export function usePomodoroTimer(
     setBreakPresetMinutes,
     toggleRunning,
     startBreak,
+    skipToFocus,
+    resetTimer,
+    endSession,
   };
 }


### PR DESCRIPTION
## 요약
- 업무계획 페이지 Timer 카드 UI를 퍼블리싱하고 퍼블리싱 범위의 인터랙션을 연결함
- 타이머 설정 BottomSheet에 저장/취소 흐름과 컨트롤 아이콘 툴팁을 추가함
- 향후 Roadmap 연동을 위해 타이머 상태 제어를 `WorkPlanTimerSection`으로 올리고 `TimerCard`를 props 기반 표시 컴포넌트로 분리함
- Timeline에 집중 중단(incomplete) 스탬프와 실제 휴식 시간 기록이 남도록 보정함

## 테스트
- `pnpm.cmd exec tsc --noEmit`
- pre-commit hooks: `prettier --check`, `eslint`

## 관련 이슈
- closes #94
- 후속 연동 이슈: #128