### PR TITLE
feat(attendance): 근태현황 카드 실데이터 연동

### DIFF
--- a/src/components/features/attendance/AttendanceDashboardCard.tsx
+++ b/src/components/features/attendance/AttendanceDashboardCard.tsx
@@ -7,6 +7,7 @@ import { useMemo } from 'react';
 import { userAtom } from '@/store/atoms';
 import { useAttendanceLogs } from '@/hooks/useAttendanceLogs';
 import { getKstDateRange, getKstDateString } from '@/lib/attendance';
+import type { AttendanceLogsParams } from '@/types/attendance';
 
 const DAY_LABELS = ['월', '화', '수', '목', '금', '토', '일'] as const;
 
@@ -18,26 +19,31 @@ function calculateJoinedDays(joinedAt?: string): number {
   return Math.max(1, Math.floor(diff / (1000 * 60 * 60 * 24)) + 1);
 }
 
-// 현재 월의 범위를 계산 (AttendanceCalendar와 동일한 방식으로 캐시 공유)
-function getCurrentMonthRange() {
+// 이번 주가 두 달에 걸치면 두 달 범위를 커버하는 쿼리 범위 반환
+// 같은 달이면 AttendanceCalendar와 동일한 monthly key → 캐시 공유
+function getQueryRange(): AttendanceLogsParams {
   const today = getKstDateString();
+  const { from: weekFrom, to: weekTo } = getKstDateRange('week');
   const [year, month] = today.split('-').map(Number);
   const lastDay = new Date(Date.UTC(year, month, 0)).getUTCDate();
-  return {
-    from: `${year}-${String(month).padStart(2, '0')}-01`,
-    to: `${year}-${String(month).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`,
-  };
+  const monthFrom = `${year}-${String(month).padStart(2, '0')}-01`;
+  const monthTo = `${year}-${String(month).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
+
+  // 주 시작일이 이번 달 안에 있으면 monthly 범위 (캘린더와 캐시 공유)
+  if (weekFrom >= monthFrom) return { from: monthFrom, to: monthTo };
+
+  // 월초 주차: 이전 달까지 포함하도록 주간 범위로 확장
+  return { from: weekFrom, to: weekTo };
 }
 
 export default function AttendanceDashboardCard() {
   const user = useAtomValue(userAtom);
-  // 캘린더와 동일한 월별 범위 사용 → React Query 캐시 공유, 별도 fetch 없음
-  const monthRange = useMemo(() => getCurrentMonthRange(), []);
-  const { logs } = useAttendanceLogs(monthRange);
+  const queryRange = useMemo(() => getQueryRange(), []);
+  const { logs, uiState } = useAttendanceLogs(queryRange);
 
   const joinedDays = calculateJoinedDays(user?.joinedAt);
+  const isReady = uiState.state === 'ready' || uiState.state === 'empty';
 
-  // 이번 주 월~일 날짜 배열 생성 후 월별 logs에서 해당 날짜 레코드 검색
   const weekDays = useMemo(() => {
     const today = getKstDateString();
     const { from: weekFrom } = getKstDateRange('week');
@@ -49,10 +55,11 @@ export default function AttendanceDashboardCard() {
       const dateStr = d.toISOString().slice(0, 10);
       const isFuture = dateStr > today;
       const record = logMap.get(dateStr);
-      const attended = !isFuture && !!record && record.status !== 'absent';
+      const attended =
+        isReady && !isFuture && !!record && record.status !== 'absent';
       return { label, attended };
     });
-  }, [logs]);
+  }, [logs, isReady]);
 
   return (
     <section className="h-full rounded-[5px] bg-grey-100 p-6">


### PR DESCRIPTION
## Summary

- **입사한 지 N일차**: `userAtom.joinedAt` 기반으로 실시간 계산
- **이번 주 근무일 체크박스**: `AttendanceCalendar`과 동일한 monthly query key 공유 → 별도 네트워크 요청 없이 캐시 재사용, `Map` 기반 O(1) 날짜 룩업
- **다음 승진까지**: 게이미피케이션 이슈(#148) 구현 전까지 `—` 표시

## Notes

`다음 승진까지` 항목은 #148 갓생 점수 시스템 구현 이후 채워질 예정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

**개선 사항**
- 주간 근무 현황이 실제 출근 기록을 기반으로 정확하게 표시됩니다(미래 날짜 제외, 로드/빈 상태 고려).
- 요일 체크박스가 출근 여부에 따라 동작하도록 개선되었습니다.
- 입사한 지 기간이 실제 입사일을 기반으로 자동 계산됩니다(유효하지 않은 값은 최소값으로 처리).
- 다음 승진 항목은 값이 없을 경우 대시로 표시되고 시각적으로 구분됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->