### PR TITLE
feat(attendance): 연간 근태 히트맵 실데이터 연동

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,13 @@
 @plugin "@tailwindcss/typography";
 @custom-variant dark (:root.dark &);
 
+.scrollbar-none {
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
 html,
 body {
   height: 100%;

--- a/src/components/features/attendance/AttendanceHeatmap.tsx
+++ b/src/components/features/attendance/AttendanceHeatmap.tsx
@@ -2,6 +2,9 @@
 
 import clsx from 'clsx';
 import { Icon } from '@iconify/react';
+import { useMemo } from 'react';
+import { useAttendanceLogs } from '@/hooks/useAttendanceLogs';
+import { getKstDateString } from '@/lib/attendance';
 
 type HeatStatus = 'in' | 'out' | 'empty';
 
@@ -11,52 +14,77 @@ type HeatCell = {
 };
 
 const MONTH_LABELS = Array.from({ length: 12 }, (_, i) => `${i + 1}월`);
-const DAYS_IN_MONTH = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]; // 2025년은 평년
-
-// 요일 라벨: 37개 (최대 한 달 + 빈 셀)
 const DAY_LABELS = Array.from(
   { length: 37 },
   (_, i) => ['월', '화', '수', '목', '금', '토', '일'][i % 7]
 );
 
-// 2025년 각 월 1일의 요일 계산 (0=월요일, 1=화요일, ..., 6=일요일)
-const getFirstDayOfMonth = (year: number, month: number): number => {
-  const date = new Date(year, month, 1);
-  const day = date.getDay(); // 0=일요일, 1=월요일, ..., 6=토요일
-  return (day + 6) % 7; // 월요일 기준으로 변환
-};
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
 
-// 2025년 캘린더 데이터
-const dummyHeatmap: HeatCell[][] = MONTH_LABELS.map((_, monthIdx) => {
-  const daysInMonth = DAYS_IN_MONTH[monthIdx];
-  const firstDay = getFirstDayOfMonth(2025, monthIdx);
-  const cells: HeatCell[] = [];
+function getDaysInMonth(year: number, month: number): number {
+  const days = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return month === 1 && isLeapYear(year) ? 29 : days[month];
+}
 
-  // 앞 빈 셀 (월 시작 전)
-  for (let i = 0; i < firstDay; i++) {
-    cells.push({ day: 0, status: 'empty' });
-  }
-
-  // 실제 날짜 셀
-  for (let day = 1; day <= daysInMonth; day++) {
-    const status = (monthIdx + day) % 3 === 0 ? 'out' : 'in';
-    cells.push({ day, status });
-  }
-
-  // 뒤 빈 셀 (37개 맞추기)
-  const totalCells = firstDay + daysInMonth;
-  const emptyCells = 37 - totalCells;
-  for (let i = 0; i < emptyCells; i++) {
-    cells.push({ day: 0, status: 'empty' });
-  }
-
-  return cells;
-});
+function getFirstDayOfMonth(year: number, month: number): number {
+  const day = new Date(year, month, 1).getDay();
+  return (day + 6) % 7; // 0=월요일 기준
+}
 
 export function AttendanceHeatmap() {
+  const today = getKstDateString();
+  const year = Number(today.split('-')[0]);
+  const yearRange = useMemo(
+    () => ({ from: `${year}-01-01`, to: `${year}-12-31` }),
+    [year]
+  );
+
+  const { logs } = useAttendanceLogs(yearRange);
+
+  const heatmap = useMemo<HeatCell[][]>(() => {
+    const logMap = new Map(logs.map(r => [r.date, r]));
+
+    return MONTH_LABELS.map((_, monthIdx) => {
+      const daysInMonth = getDaysInMonth(year, monthIdx);
+      const firstDay = getFirstDayOfMonth(year, monthIdx);
+      const cells: HeatCell[] = [];
+
+      // 앞 빈 셀
+      for (let i = 0; i < firstDay; i++) {
+        cells.push({ day: 0, status: 'empty' });
+      }
+
+      // 날짜 셀
+      for (let day = 1; day <= daysInMonth; day++) {
+        const mm = String(monthIdx + 1).padStart(2, '0');
+        const dd = String(day).padStart(2, '0');
+        const dateStr = `${year}-${mm}-${dd}`;
+        const record = logMap.get(dateStr);
+
+        let status: HeatStatus;
+        if (record && dateStr <= today && record.status !== 'absent') {
+          status = 'in';
+        } else {
+          status = 'out'; // 결근·기록없음·미래 모두 primary-100으로 표시
+        }
+
+        cells.push({ day, status });
+      }
+
+      // 뒤 빈 셀 (37칸 맞추기)
+      const filled = firstDay + daysInMonth;
+      for (let i = filled; i < 37; i++) {
+        cells.push({ day: 0, status: 'empty' });
+      }
+
+      return cells;
+    });
+  }, [logs, year, today]);
+
   return (
     <div className="w-full max-w-[1440px] bg-grey-100 rounded-[5px] p-6">
-      {/* 제목 */}
       <div className="mb-6 inline-flex justify-start items-end gap-1">
         <Icon
           icon="icon-park:endocrine"
@@ -64,14 +92,13 @@ export function AttendanceHeatmap() {
           aria-hidden="true"
         />
         <h2 className="text-grey-900 text-base font-normal font-['DNF_Bit_Bit_v2']">
-          이번 년도 근태 기록
+          {year}년도 근태 기록
         </h2>
       </div>
 
-      {/* 히트맵 컨테이너 */}
-      <div className="overflow-x-auto -mx-6 px-6">
+      <div className="overflow-x-auto scrollbar-none -mx-6 px-6">
         <div className="flex gap-2 min-w-max">
-          {/* 월 라벨 (왼쪽) */}
+          {/* 월 라벨 */}
           <div className="flex flex-col gap-[5px] pt-6">
             {MONTH_LABELS.map((label, idx) => (
               <div
@@ -85,7 +112,6 @@ export function AttendanceHeatmap() {
 
           {/* 요일 헤더 + 히트맵 */}
           <div className="flex flex-col gap-1">
-            {/* 요일 헤더 */}
             <div className="flex gap-[5px]">
               {DAY_LABELS.map((label, idx) => (
                 <div
@@ -97,9 +123,8 @@ export function AttendanceHeatmap() {
               ))}
             </div>
 
-            {/* 히트맵 행들 */}
             <div className="flex flex-col gap-[5px]">
-              {dummyHeatmap.map((row, rowIdx) => (
+              {heatmap.map((row, rowIdx) => (
                 <div key={`row-${rowIdx}`} className="flex gap-[5px]">
                   {row.map((cell, cellIdx) => {
                     if (cell.status === 'empty') {
@@ -127,10 +152,10 @@ export function AttendanceHeatmap() {
                       >
                         <div
                           className={clsx(
-                            'text-[10px] font-medium font-["S-Core_Dream"] leading-none',
+                            'text-[10px] font-["S-Core_Dream"] leading-none',
                             cell.status === 'in'
-                              ? 'text-white'
-                              : 'text-primary-500'
+                              ? 'font-medium text-white'
+                              : 'font-bold text-primary-500'
                           )}
                         >
                           {cell.day}


### PR DESCRIPTION

<img width="1392" height="554" alt="스크린샷 2026-03-20 173017" src="https://github.com/user-attachments/assets/72a3bfcc-4cb7-4f8d-b41c-2b35dd676fc8" />



﻿## 📋 작업 내용
근태 히트맵을 연간 실데이터 기반으로 표시하도록 구현했습니다.

## 🎯 관련 이슈
Refs #77

## 📝 변경사항
- AttendanceHeatmap의 더미 데이터를 연간 출근 로그 기반 heatmap으로 교체했습니다.
- 현재 연도 기준으로 월별 일수, 윤년, 시작 요일을 계산해 동적으로 렌더링합니다.
- 가로 스크롤 영역에 스크롤바 숨김 스타일을 추가해 UI를 정리했습니다.

## ✅ 체크리스트
- [x] 코드 리뷰 받을 준비 완료
- [x] 테스트 완료
- [ ] 문서 업데이트 (필요시)

## 📸 스크린샷
<!-- UI 변경시만 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 근태 기록 히트맵이 실제 출석 데이터를 기반으로 동적 표시되도록 개선되었습니다.
  * 현재 연도를 자동으로 반영하여 정확한 기록을 제공합니다.

* **스타일 개선**
  * 스크롤바 표시 개선 및 사용자 인터페이스 레이블 업데이트가 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->