### PR TITLE
fix: 루틴 모드 새로고침 후 큐 유실로 인한 조기 종료 버그 수정

### DIFF
--- a/src/app/_actions/sessionActions.ts
+++ b/src/app/_actions/sessionActions.ts
@@ -24,6 +24,7 @@ export type ActiveSessionRow = {
   routine_title: string | null;
   routine_index: number | null;
   routine_total_count: number | null;
+  routine_queue: { id: string; title: string }[] | null;
   updated_at: string;
 };
 
@@ -72,6 +73,7 @@ export async function upsertActiveSession(input: {
   isRunning: boolean;
   sessionMode: SessionMode;
   activeRoutine: ActiveRoutine | null;
+  routineQueue?: { id: string; title: string }[] | null;
 }): Promise<MutationResponse> {
   const client = await getUserSupabaseClient();
   if (!client.ok) return client;
@@ -90,6 +92,7 @@ export async function upsertActiveSession(input: {
       routine_title: input.activeRoutine?.title ?? null,
       routine_index: input.activeRoutine?.index ?? null,
       routine_total_count: input.activeRoutine?.totalCount ?? null,
+      routine_queue: input.routineQueue ?? null,
       updated_at: new Date().toISOString(),
     },
     { onConflict: 'user_id' } // user_id 충돌 시 update

--- a/src/components/features/task-plan/application/useActiveSession.ts
+++ b/src/components/features/task-plan/application/useActiveSession.ts
@@ -62,6 +62,7 @@ export function useUpsertActiveSession() {
       isRunning: boolean;
       sessionMode: SessionMode;
       activeRoutine: ActiveRoutine | null;
+      routineQueue?: { id: string; title: string }[] | null;
     }) => upsertActiveSession(input),
     // 저장 실패해도 UI는 계속 동작해야 하므로 onError는 콘솔만
     onError: error => {

--- a/src/components/features/task-plan/hooks/useSessionOrchestrator.ts
+++ b/src/components/features/task-plan/hooks/useSessionOrchestrator.ts
@@ -249,6 +249,7 @@ export function useSessionOrchestrator({
       routine_title,
       routine_index,
       routine_total_count,
+      routine_queue,
     } = activeSessionData;
 
     setSessionMode(session_mode);
@@ -265,6 +266,10 @@ export function useSessionOrchestrator({
         index: routine_index,
         totalCount: routine_total_count,
       });
+    }
+
+    if (session_mode === 'routine' && routine_queue) {
+      routineQueueRef.current = routine_queue;
     }
 
     const startedAt = new Date(started_at);
@@ -357,6 +362,7 @@ export function useSessionOrchestrator({
         isRunning: true,
         sessionMode: 'routine',
         activeRoutine: newRoutine,
+        routineQueue: routines,
       });
 
       onToast?.(`'${routines[0].title}' 루틴을 시작했어요.`, 'success');


### PR DESCRIPTION
## 문제

루틴 모드 진행 중 새로고침하면 현재 루틴 정보만 복원되고, `routineQueueRef`가 복원되지 않아 다음 루틴 전환 시 조기 종료됩니다.

closes #158 
## 원인

- 시작 시: 루틴 큐를 `routineQueueRef`(메모리)에 저장
- 복원 시: 현재 루틴 정보만 복원, 큐는 복원 안 함
- 다음 루틴 전환: `routineQueueRef`를 읽어 결정

→ 새로고침 후 큐가 비어있어 완료/스킵 시 즉시 전체 세션 종료.

## 수정 내용

- `active_sessions` 테이블에 `routine_queue JSONB` 컬럼 추가 (별도 SQL 실행 필요)
- `startRoutine` 시 `routineQueue` 배열을 DB에 함께 저장
- 세션 복원 시 `routine_queue`로 `routineQueueRef` 재설정

## SQL 마이그레이션

\`\`\`sql
ALTER TABLE active_sessions
ADD COLUMN IF NOT EXISTS routine_queue JSONB;
\`\`\`

## 테스트

- [ ] 루틴 2개 이상 시작 → 새로고침 → 스킵/완료 시 다음 루틴으로 정상 전환
- [ ] 루틴 3개 시작 → 중간에 새로고침 → 남은 루틴 순서대로 전환 → 마지막 완료 토스트
- [ ] manual 모드(루틴 1개) regression 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 세션 중 루틴 대기열 정보가 자동으로 저장되고 복원됩니다.
  * 루틴 세션을 재개할 때 이전 상태가 더욱 정확하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->