### PR TITLE
Feat: 댓글 수정 기능 추가

### DIFF
--- a/src/components/features/board-post/comment/CommentActionMenu.tsx
+++ b/src/components/features/board-post/comment/CommentActionMenu.tsx
@@ -2,7 +2,11 @@
 
 import { userAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
-import { canDeleteComment, canPinComment } from './domain/commentPermissions';
+import {
+  canDeleteComment,
+  canEditComment,
+  canPinComment,
+} from './domain/commentPermissions';
 
 interface CommentActionMenuProps {
   commentId: string;
@@ -11,6 +15,7 @@ interface CommentActionMenuProps {
   isPinned: boolean;
   onDelete?: () => void;
   onPin?: (commentId: string, is_pinned: boolean) => void;
+  onEdit?: () => void;
 }
 
 export function CommentActionMenu({
@@ -20,9 +25,11 @@ export function CommentActionMenu({
   isPinned,
   onDelete,
   onPin,
+  onEdit,
 }: CommentActionMenuProps) {
   const user = useAtomValue(userAtom);
   const showDelete = !!user && canDeleteComment(user.id, commentAuthorId);
+  const showEdit = !!user && canEditComment(user.id, commentAuthorId, isPinned);
   const showPin = !!user && canPinComment(user.id, postAuthorId);
 
   return (
@@ -32,6 +39,7 @@ export function CommentActionMenu({
           {isPinned ? '고정 해제' : '고정'}
         </div>
       )}
+      {showEdit && <div onClick={onEdit}>수정</div>}
       {showDelete && <div onClick={onDelete}>삭제</div>}
     </div>
   );

--- a/src/components/features/board-post/comment/CommentItem.tsx
+++ b/src/components/features/board-post/comment/CommentItem.tsx
@@ -7,16 +7,23 @@ import { parseTextWithLinks } from './ParserTextWithLinks';
 import { formatDate } from '@/lib/formatDate';
 import { Comment } from '@/types/board';
 import { CommentActionMenu } from './CommentActionMenu';
-import { canDeleteComment, canPinComment } from './domain/commentPermissions';
+import {
+  canDeleteComment,
+  canEditComment,
+  canPinComment,
+} from './domain/commentPermissions';
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { fetchReplies } from './api/commentApi';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchReplies, updateCommentContent } from './api/commentApi';
 import { CommentInput } from './CommentInput';
 import IconButton from '@/components/ui/IconButton';
 import { overlay } from 'overlay-kit';
 import BottomSheet from '@/components/ui/BottomSheet';
 import { userAtom } from '@/store/atoms';
 import { useAtomValue } from 'jotai';
+import { useToast } from '@/providers/ToastProvider';
+import TextArea from '@/components/ui/TextArea';
+import Button from '@/components/ui/Button';
 
 type CommentItemProps = Comment & {
   postId: string;
@@ -57,6 +64,30 @@ export function CommentItem({
   const [showReplies, setShowReplies] = useState(false);
   const [localReplyCount, setLocalReplyCount] = useState(reply_count);
   const [replyToName, setReplyToName] = useState(author_name);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState(content);
+  const [localContent, setLocalContent] = useState(content);
+
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  const { mutate: submitEdit, isPending: isEditPending } = useMutation({
+    mutationFn: () => updateCommentContent(postId, id, editContent.trim()),
+    onSuccess: () => {
+      setLocalContent(editContent.trim());
+      setIsEditing(false);
+      if (parent_id) {
+        queryClient.invalidateQueries({ queryKey: ['replies', parent_id] });
+      } else {
+        queryClient.invalidateQueries({ queryKey: ['comments', postId] });
+      }
+    },
+    onError: () =>
+      toast.error('수정에 실패했습니다. 잠시 후 다시 시도해주세요.'),
+  });
+
+  const canEdit =
+    !!currentUser && canEditComment(currentUser.id, user_id, is_pinned);
 
   const { data: replies = [], isFetching } = useQuery({
     queryKey: ['replies', id],
@@ -117,6 +148,15 @@ export function CommentItem({
                       onPin?.(commentId, isPinned);
                       close();
                     }}
+                    onEdit={
+                      canEdit
+                        ? () => {
+                            setEditContent(localContent);
+                            setIsEditing(true);
+                            close();
+                          }
+                        : undefined
+                    }
                   />
                 </BottomSheet>
               ))
@@ -125,14 +165,46 @@ export function CommentItem({
         </div>
       </div>
 
-      <div className="flex items-center gap-2">
-        {is_pinned && (
-          <Badge variant="blue" size="xs">
-            고정댓글
-          </Badge>
-        )}
-        {parseTextWithLinks(content)}
-      </div>
+      {isEditing ? (
+        <div className="mr-6">
+          <TextArea
+            value={editContent}
+            onChange={e => setEditContent(e.target.value)}
+            maxLength={1000}
+            className="border-grey-200 rounded-none"
+            autoFocus
+          />
+          <div className="flex justify-end gap-2 mt-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              type="button"
+              onClick={() => setIsEditing(false)}
+              disabled={isEditPending}
+            >
+              취소
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              type="button"
+              disabled={!editContent.trim() || isEditPending}
+              onClick={() => submitEdit()}
+            >
+              {isEditPending ? '저장 중...' : '저장'}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2">
+          {is_pinned && (
+            <Badge variant="blue" size="xs">
+              고정댓글
+            </Badge>
+          )}
+          {parseTextWithLinks(localContent)}
+        </div>
+      )}
 
       {/* 답글 더보기 / 숨기기 */}
       {!isReply && displayReplyCount > 0 && (

--- a/src/components/features/board-post/comment/api/commentApi.ts
+++ b/src/components/features/board-post/comment/api/commentApi.ts
@@ -64,3 +64,18 @@ export async function patchComment(
     throw new Error('pin failed');
   }
 }
+
+export async function updateCommentContent(
+  postId: string,
+  commentId: string,
+  content: string
+) {
+  const res = await fetch(`/api/board/posts/${postId}/comments/${commentId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
+  if (!res.ok) {
+    throw new Error('edit failed');
+  }
+}

--- a/src/components/features/board-post/comment/domain/commentPermissions.ts
+++ b/src/components/features/board-post/comment/domain/commentPermissions.ts
@@ -5,6 +5,14 @@ export function canDeleteComment(
   return currentUserId === commentAuthorId;
 }
 
+export function canEditComment(
+  currentUserId: string,
+  commentAuthorId: string,
+  isPinned: boolean
+) {
+  return currentUserId === commentAuthorId && !isPinned;
+}
+
 export function canPinComment(currentUserId: string, postAuthorId: string) {
   return currentUserId === postAuthorId;
 }


### PR DESCRIPTION

## 📋 작업 내용
<!-- 한 줄 요약 -->

## 🎯 관련 이슈
Closes #173 

## 📝 변경사항
- 본인 댓글 + 고정되지 않은 경우에만 수정 가능 (canEditComment 권한 추가)
- 케밥 메뉴에 수정 항목 추가 (CommentActionMenu)
- 수정 클릭 시 인라인 textarea 전환, 저장/취소 버튼 제공
- 저장 성공 시 localContent 낙관적 업데이트 + 쿼리 무효화


## ✅ 체크리스트
- [ ] 본인 댓글 케밥 메뉴에 수정 항목 노출 확인
- [ ] 고정된 댓글은 수정 항목 미노출 확인
- [ ] 수정 저장 후 내용 즉시 반영 확인
- [ ] 취소 시 원래 내용으로 복귀 확인
- [ ] 타인 댓글에 수정 항목 미노출 확인

## 📸 스크린샷
<!-- UI 변경시만 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 수정 기능이 추가되었습니다. 사용자는 자신이 작성한 댓글을 수정할 수 있으며, 인라인 편집 UI를 통해 변경 내용을 저장하거나 취소할 수 있습니다. 고정된 댓글은 수정할 수 없으며, 수정 성공 시 실시간으로 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->