### PR TITLE
refactor: board 게시글/댓글 삭제를 hard delete에서 soft delete로 전환

### DIFF
--- a/src/app/_actions/homeBoard.ts
+++ b/src/app/_actions/homeBoard.ts
@@ -14,6 +14,7 @@ export async function getMemberAllBoards(
   const { data, error } = await supabase
     .from('board_posts')
     .select('id, scope, board, dept, title, created_at')
+    .is('deleted_at', null)
     .order('created_at', { ascending: false })
     .limit(limit);
 
@@ -45,6 +46,7 @@ export async function getGuestAnnouncements(
     .select('id, scope, board, title, created_at')
     .eq('scope', 'company')
     .eq('board', '공지사항')
+    .is('deleted_at', null)
     .order('created_at', { ascending: false })
     .limit(limit);
 
@@ -73,6 +75,7 @@ export async function getGuestCommunity(
   const { data, error } = await supabase
     .from('board_posts')
     .select('id, scope, board, dept, title, created_at')
+    .is('deleted_at', null)
     .order('created_at', { ascending: false })
     .limit(limit);
 

--- a/src/app/api/board/posts/[postId]/comments/[commentId]/route.ts
+++ b/src/app/api/board/posts/[postId]/comments/[commentId]/route.ts
@@ -70,6 +70,7 @@ export async function PATCH(req: Request, { params }: Params) {
     .select('user_id')
     .eq('id', commentId)
     .eq('post_id', postId)
+    .is('deleted_at', null)
     .single();
 
   if (!existing) {
@@ -111,6 +112,7 @@ export async function DELETE(_req: Request, { params }: Params) {
     .select('user_id')
     .eq('id', commentId)
     .eq('post_id', postId)
+    .is('deleted_at', null)
     .single();
 
   if (!existing) {
@@ -122,7 +124,7 @@ export async function DELETE(_req: Request, { params }: Params) {
 
   const { error } = await supabase
     .from('board_post_comments')
-    .delete()
+    .update({ deleted_at: new Date().toISOString() })
     .eq('id', commentId);
 
   if (error) {

--- a/src/app/api/board/posts/[postId]/comments/route.ts
+++ b/src/app/api/board/posts/[postId]/comments/route.ts
@@ -32,6 +32,7 @@ export async function GET(
       .select('*, board_post_comment_likes(user_id)')
       .eq('post_id', postId)
       .eq('parent_id', parentId)
+      .is('deleted_at', null)
       .order('created_at', { ascending: true });
 
     if (error)
@@ -56,6 +57,7 @@ export async function GET(
     .select('*, board_post_comment_likes(user_id)', { count: 'exact' })
     .eq('post_id', postId)
     .is('parent_id', null)
+    .is('deleted_at', null)
     .order('is_pinned', { ascending: false })
     .order('created_at', { ascending: true })
     .range((page - 1) * COMMENTS_PER_PAGE, page * COMMENTS_PER_PAGE - 1);

--- a/src/app/board/[postId]/page.tsx
+++ b/src/app/board/[postId]/page.tsx
@@ -48,7 +48,8 @@ export default async function BoardPostPage({
     board_post_bookmarks(user_id)
   `
     )
-    .eq('id', postId);
+    .eq('id', postId)
+    .is('deleted_at', null);
 
   if (user) {
     baseQuery

--- a/src/app/board/_actions/deleteBoardPost.ts
+++ b/src/app/board/_actions/deleteBoardPost.ts
@@ -62,9 +62,8 @@ export async function deleteBoardPost(
     }
   }
 
-  // CASCADE 삭제 전에 Storage 경로를 미리 수집
-  // (board_post_images.post_id → board_posts.id ON DELETE CASCADE 로 인해
-  //  게시글 삭제 후 조회하면 row가 이미 없음)
+  // soft delete 전에 Storage 경로를 미리 수집
+  // (deleted_at 세팅 후에는 RLS SELECT 정책이 해당 row를 숨겨 조회 불가)
   const { data: images, error: imagesError } = await supabase
     .from('board_post_images')
     .select('url')
@@ -81,19 +80,20 @@ export async function deleteBoardPost(
     .map(img => extractStoragePath(img.url))
     .filter((p): p is string => p !== null);
 
-  // RLS "Allow delete own posts" + "Allow delete by admin" 정책이 처리
-  // → 유저 세션 클라이언트 사용 (exec_quotes 패턴과 일관성 유지)
-  const { error: deleteError } = await supabase
+  // soft delete: admin 클라이언트로 RLS 우회
+  // (작성자/관리자 권한 검사는 위에서 완료)
+  const { error: deleteError } = await admin
     .from('board_posts')
-    .delete()
+    .update({ deleted_at: new Date().toISOString() })
     .eq('id', postId);
 
   if (deleteError) {
-    console.error('[deleteBoardPost] delete failed', deleteError);
+    console.error('[deleteBoardPost] soft delete failed', deleteError);
     return { ok: false, error: '게시글 삭제 중 오류가 발생했습니다.' };
   }
 
-  // DB 삭제 성공 후 Storage 정리 (best-effort)
+  // DB soft delete 성공 후 Storage 정리 (best-effort)
+  // pg_cron이 30일 후 DB row를 purge할 때 board_post_images도 CASCADE 정리됨
   await cleanupStoragePaths(storagePaths);
 
   return { ok: true };

--- a/src/app/board/_actions/listBoardPosts.ts
+++ b/src/app/board/_actions/listBoardPosts.ts
@@ -54,6 +54,7 @@ export async function listBoardPostsForList({
       { count: 'exact' }
     )
     .eq('scope', scope)
+    .is('deleted_at', null)
     .order('created_at', { ascending: false })
     .range(from, to);
 


### PR DESCRIPTION
## 📋 작업 내용
<!-- 한 줄 요약 -->
게시글/댓글 삭제를 hard delete에서 soft delete로 전환

## 🎯 관련 이슈
Closes #181 

## 📝 변경사항
- `deleteBoardPost`: `DELETE` → `UPDATE deleted_at` (admin client, 관리자 케이스 RLS UPDATE 정책 없음)
- 댓글 DELETE route: `DELETE` → `UPDATE deleted_at` (user client, `board_post_comments` RLS 비활성)
- Storage 이미지는 soft delete 시점에 즉시 제거 (pg_cron은 SQL only라 Storage API 호출 불가)
- 모든 SELECT 쿼리에 `.is('deleted_at', null)` 필터 추가
  (listBoardPosts, homeBoard 3곳, 게시글 상세, 댓글 루트/답글)
- soft-deleted 댓글에 수정/핀 시도 시 404 반환

## DB 작업 (Supabase 웹에서 별도 실행 필요)

- `board_post_comments.deleted_at timestamptz` 컬럼 추가
- `board_posts_select` RLS에 `deleted_at IS NULL` 조건 추가
- `deleted_at` partial index 추가
- pg_cron job `purge-deleted-board-content` 등록 (매일 KST 03:00, 30일 후 hard purge)
- `board_post_comments_with_reply_count` 뷰에 `deleted_at` 컬럼 추가 및 reply_count에서 삭제된 답글 제외
- `on_comment_soft_delete` 트리거 추가: soft delete 시 board_posts.comment_count 자동 감소


## ✅ 체크리스트
- [ ] 게시글 삭제 후 목록/홈에서 노출되지 않는지 확인
- [ ] 삭제된 게시글 URL 직접 접근 시 notFound 확인
- [ ] 댓글 삭제 후 목록에서 노출되지 않는지 확인
- [ ] 관리자가 타인 게시글 삭제 가능한지 확인
- [ ] Storage 이미지가 soft delete 시 즉시 제거되는지 확인

## 📸 스크린샷
<!-- UI 변경시만 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 삭제된 게시물 및 댓글이 모든 피드와 목록에서 올바르게 숨겨집니다.
  * 게시물 및 댓글 삭제 시 일관된 데이터 처리를 보장합니다.
  * 삭제된 콘텐츠가 API 응답에서 제외됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->