### PR TITLE
fix: 게시글 조회수 중복 누적 버그 수정

### DIFF
--- a/src/components/features/board-post/ViewCountTracker.tsx
+++ b/src/components/features/board-post/ViewCountTracker.tsx
@@ -34,10 +34,17 @@ export function ViewCountTracker({ postId }: ViewCountTrackerProps) {
 
     // fetch 전에 먼저 세팅 — 동시 마운트로 인한 중복 요청 방지
     setLastViewed(key);
-    fetch(`/api/board/posts/${postId}/view`, { method: 'POST' }).catch(() => {
-      // 실패 시 다음 방문에서 재시도할 수 있도록 롤백
-      localStorage.removeItem(key);
-    });
+    fetch(`/api/board/posts/${postId}/view`, { method: 'POST' })
+      .then(res => {
+        if (!res.ok) {
+          // HTTP 오류 응답 시 롤백
+          localStorage.removeItem(key);
+        }
+      })
+      .catch(() => {
+        // 실패 시 다음 방문에서 재시도할 수 있도록 롤백
+        localStorage.removeItem(key);
+      });
   }, [postId]);
 
   return null;


### PR DESCRIPTION
## 📋 작업 내용
<!-- 한 줄 요약 -->

## 🎯 관련 이슈
Closes #190 

## 버그 원인

`ViewCountTracker`가 짧은 시간 안에 여러 번 마운트될 때
(React Strict Mode의 의도적 이중 실행 + 페이지 re-render 조합)
**localStorage 체크와 fetch 완료 사이의 시간 간격** 때문에 race condition이 발생했습니다.

**기존 흐름 (문제):**
마운트 1 → localStorage: null → fetch 시작 (아직 완료 전)
마운트 2 → localStorage: null → fetch 시작 (아직 완료 전)
마운트 3 → localStorage: null → fetch 시작 (아직 완료 전)
마운트 4 → localStorage: null → fetch 시작
마운트 1 fetch 완료 → localStorage 세팅  ← 이미 4개 발사된 후

localStorage에 "봤음" 표시를 **fetch가 완료된 후**에 세팅하다 보니,
여러 번의 마운트가 모두 `null`을 보고 fetch를 중복 요청, 중복 요청된 fetch 수만큼 조회수 증가

## 해결 방법

fetch **전에** localStorage를 먼저 세팅해 이후 마운트들이 즉시 early return하도록 변경.
fetch 실패 시에는 localStorage를 롤백하여 다음 방문 때 재시도 가능하게 처리.

**수정 후 흐름:**
마운트 1 → localStorage: null → 즉시 세팅 → fetch 시작
마운트 2 → localStorage: 있음 → return ✋
마운트 3 → localStorage: 있음 → return ✋
마운트 4 → localStorage: 있음 → return ✋

## ✅ 체크리스트
- [ ] 게시글 진입 시 네트워크 탭에서 `/view` 요청이 1번만 발생하는지 확인
- [ ] 24시간 이내 재방문 시 `/view` 요청이 발생하지 않는지 확인
- [ ] localStorage 제거 후 재방문 시 정상적으로 1번 요청되는지 확인

## 📸 스크린샷
<!-- UI 변경시만 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 조회 수 추적 기능의 안정성이 개선되었습니다. 네트워크 오류 발생 시 더 효과적으로 복구할 수 있으며, 조회 데이터가 더 정확하게 보존됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->