### PR TITLE
fix: stale session 보안·무결성·탐지 범위 3종 수정 (#169, #168, #179)

### DIFF
--- a/src/app/_actions/__tests__/attendanceToday.stale.test.ts
+++ b/src/app/_actions/__tests__/attendanceToday.stale.test.ts
@@ -192,30 +192,15 @@ describe('getAttendanceToday 분기 로직', () => {
       expect(result.type).toBe('stale');
       expect(result.row?.clock_in_at).toBe('2026-03-27T00:15:00.000Z');
     });
-  });
 
-  describe('레코드 없음', () => {
-    it('rows가 비어있으면 none', () => {
-      const result = resolveActiveRow([], TODAY, YESTERDAY, 9);
-      expect(result.type).toBe('none');
-    });
-
-    it('오늘/어제 외 날짜도 clock_out=null이면 none (rows에 없는 경우)', () => {
-      // 빈 rows → DB 쿼리 범위 밖이므로 stale 탐지 불가
-      const result = resolveActiveRow([], TODAY, YESTERDAY, 9);
-      expect(result.type).toBe('none');
-    });
-
-    it('이틀 전 미마감 레코드 → stale (multi-day 케이스 #179)', () => {
+    it('multi-day stale: 이틀 전 미마감 레코드 → stale (#179)', () => {
       // 금→월 처럼 2일 이상 이전 미마감 세션이 rows에 포함된 경우
-      const rows = [
-        makeRow({ work_date: '2026-03-25', clock_out_at: null }), // 그저께
-      ];
+      const rows = [makeRow({ work_date: '2026-03-25', clock_out_at: null })];
       const result = resolveActiveRow(rows, TODAY, YESTERDAY, 9);
       expect(result.type).toBe('stale');
     });
 
-    it('이틀 전 레코드가 clock_out 있으면 stale 아님', () => {
+    it('multi-day stale: 이틀 전 레코드가 clock_out 있으면 stale 아님', () => {
       const rows = [
         makeRow({
           work_date: '2026-03-25',

--- a/src/app/_actions/__tests__/attendanceToday.stale.test.ts
+++ b/src/app/_actions/__tests__/attendanceToday.stale.test.ts
@@ -35,11 +35,12 @@ function resolveActiveRow(
 
   if (activeCarryOverRow) return { type: 'carryOver', row: activeCarryOverRow };
 
+  // work_date < today 로 multi-day stale 탐지 (#179)
   const staleRow =
     currentKstHour >= 6
       ? (rows.find(
           r =>
-            r.work_date === yesterday &&
+            r.work_date < today &&
             r.clock_in_at !== null &&
             r.clock_out_at === null
         ) ?? null)
@@ -199,8 +200,28 @@ describe('getAttendanceToday 분기 로직', () => {
       expect(result.type).toBe('none');
     });
 
-    it('어제/오늘 외 날짜만 있어도 none', () => {
-      const rows = [makeRow({ work_date: '2026-03-25' })]; // 그저께
+    it('오늘/어제 외 날짜도 clock_out=null이면 none (rows에 없는 경우)', () => {
+      // 빈 rows → DB 쿼리 범위 밖이므로 stale 탐지 불가
+      const result = resolveActiveRow([], TODAY, YESTERDAY, 9);
+      expect(result.type).toBe('none');
+    });
+
+    it('이틀 전 미마감 레코드 → stale (multi-day 케이스 #179)', () => {
+      // 금→월 처럼 2일 이상 이전 미마감 세션이 rows에 포함된 경우
+      const rows = [
+        makeRow({ work_date: '2026-03-25', clock_out_at: null }), // 그저께
+      ];
+      const result = resolveActiveRow(rows, TODAY, YESTERDAY, 9);
+      expect(result.type).toBe('stale');
+    });
+
+    it('이틀 전 레코드가 clock_out 있으면 stale 아님', () => {
+      const rows = [
+        makeRow({
+          work_date: '2026-03-25',
+          clock_out_at: '2026-03-25T09:00:00.000Z',
+        }),
+      ];
       const result = resolveActiveRow(rows, TODAY, YESTERDAY, 9);
       expect(result.type).toBe('none');
     });

--- a/src/app/_actions/attendance.ts
+++ b/src/app/_actions/attendance.ts
@@ -77,12 +77,16 @@ export async function getAttendanceToday(): Promise<
   const now = new Date();
   const today = getKstDateString(now);
   const yesterday = getKstDateOffsetString(-1, today);
+  // 주말·공휴일 연속으로 stale session이 2일 이상 이전인 경우도 탐지하기 위해
+  // 최근 7일을 조회한다 (#179)
+  const sevenDaysAgo = getKstDateOffsetString(-7, today);
 
   const { data, error } = await client.supabase
     .from('attendance_logs')
     .select('*')
     .eq('user_id', client.user.id)
-    .in('work_date', [today, yesterday])
+    .gte('work_date', sevenDaysAgo)
+    .lte('work_date', today)
     .order('work_date', { ascending: false });
 
   if (error) {
@@ -109,12 +113,14 @@ export async function getAttendanceToday(): Promise<
     return currentKstHour < 6;
   });
 
-  // 오전 6시 이후 어제 퇴근 기록 없음 → 미처리(stale) 세션
+  // 오전 6시 이후 미마감 세션 → stale
+  // work_date < today 로 체크해 금요일 출근 후 월요일 복귀 같은
+  // 다일(multi-day) 케이스도 탐지한다 (#179)
   const staleRow =
     !todayRow && !activeCarryOverRow && currentKstHour >= 6
       ? rows.find(
           row =>
-            row.work_date === yesterday &&
+            row.work_date < today &&
             row.clock_in_at !== null &&
             row.clock_out_at === null
         )

--- a/src/lib/__tests__/attendance.stale.test.ts
+++ b/src/lib/__tests__/attendance.stale.test.ts
@@ -109,6 +109,26 @@ describe('mapAttendanceError', () => {
     expect(mapAttendanceError('Already clocked out')).toBe('ALREADY_FINALIZED');
   });
 
+  it('"Unauthorized: You can only close your own stale session" → UNAUTHENTICATED', () => {
+    expect(
+      mapAttendanceError(
+        'Unauthorized: You can only close your own stale session'
+      )
+    ).toBe('UNAUTHENTICATED');
+  });
+
+  it('"Unauthorized: You can only auto-close your own stale session" → UNAUTHENTICATED', () => {
+    expect(
+      mapAttendanceError(
+        'Unauthorized: You can only auto-close your own stale session'
+      )
+    ).toBe('UNAUTHENTICATED');
+  });
+
+  it('unauthorized 소문자도 처리 → UNAUTHENTICATED', () => {
+    expect(mapAttendanceError('unauthorized access')).toBe('UNAUTHENTICATED');
+  });
+
   it('"No clock-in record found for the given date" → NO_CHECK_IN_RECORD', () => {
     expect(
       mapAttendanceError('No clock-in record found for the given date')

--- a/src/lib/attendance.ts
+++ b/src/lib/attendance.ts
@@ -300,6 +300,10 @@ export function createAttendanceSummary(
 export function mapAttendanceError(message: string | null | undefined) {
   const normalized = message?.toLowerCase() ?? '';
 
+  if (normalized.includes('unauthorized')) {
+    return 'UNAUTHENTICATED' satisfies AttendanceErrorCode;
+  }
+
   if (normalized.includes('clocked in')) {
     return 'ALREADY_CHECKED_IN' satisfies AttendanceErrorCode;
   }

--- a/supabase/migrations/20260417000014_fix_stale_session_auth_and_cap.sql
+++ b/supabase/migrations/20260417000014_fix_stale_session_auth_and_cap.sql
@@ -45,6 +45,10 @@ BEGIN
     RAISE EXCEPTION 'Session already closed';
   END IF;
 
+  IF p_clock_out_at IS NULL THEN
+    RAISE EXCEPTION 'Invalid clock_out_at: must not be null';
+  END IF;
+
   -- #168: 하한(clock_in_at) + 상한(clock_in_at + 8h) 양방향 캡 적용
   v_capped_out := GREATEST(p_clock_out_at, v_log.clock_in_at);
   v_capped_out := LEAST(v_capped_out, v_log.clock_in_at + INTERVAL '8 hours');

--- a/supabase/migrations/20260417000014_fix_stale_session_auth_and_cap.sql
+++ b/supabase/migrations/20260417000014_fix_stale_session_auth_and_cap.sql
@@ -1,0 +1,127 @@
+-- Migration: fix stale session auth check and work_minutes lower-bound cap
+--
+-- #169  fn_close_stale_session / fn_auto_close_stale_session:
+--       auth.uid() != p_user_id 는 auth.uid()가 NULL일 때 NULL(falsy)로 평가되어
+--       미인증 호출이 인가 체크를 우회할 수 있음.
+--       IS DISTINCT FROM 으로 교체해 NULL-safe 비교를 보장한다.
+--
+-- #168  fn_close_stale_session:
+--       p_clock_out_at 이 clock_in_at 보다 이른 경우 work_minutes 가 음수가 됨.
+--       GREATEST(p_clock_out_at, v_log.clock_in_at) 로 하한 캡을 추가한다.
+
+
+-- ── fn_close_stale_session ────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.fn_close_stale_session(
+  p_user_id      uuid,
+  p_work_date    date,
+  p_clock_out_at timestamptz
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_log          public.attendance_logs;
+  v_result       public.attendance_logs;
+  v_capped_out   TIMESTAMPTZ;
+  v_work_minutes INTEGER;
+  v_next_status  TEXT;
+BEGIN
+  -- #169: IS DISTINCT FROM 으로 NULL-safe 인가 체크
+  IF auth.uid() IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Unauthorized: You can only close your own stale session';
+  END IF;
+
+  SELECT * INTO v_log
+  FROM public.attendance_logs
+  WHERE user_id = p_user_id AND work_date = p_work_date;
+
+  IF v_log.id IS NULL OR v_log.clock_in_at IS NULL THEN
+    RAISE EXCEPTION 'No clock-in record found for the given date';
+  END IF;
+
+  IF v_log.clock_out_at IS NOT NULL THEN
+    RAISE EXCEPTION 'Session already closed';
+  END IF;
+
+  -- #168: 하한(clock_in_at) + 상한(clock_in_at + 8h) 양방향 캡 적용
+  v_capped_out := GREATEST(p_clock_out_at, v_log.clock_in_at);
+  v_capped_out := LEAST(v_capped_out, v_log.clock_in_at + INTERVAL '8 hours');
+
+  v_work_minutes := FLOOR(
+    EXTRACT(EPOCH FROM (v_capped_out - v_log.clock_in_at)) / 60.0
+  )::INT;
+
+  v_next_status := CASE
+    WHEN v_work_minutes < 480 THEN 'early_leave'
+    WHEN v_log.status = 'late'  THEN 'late'
+    ELSE 'present'
+  END;
+
+  UPDATE public.attendance_logs
+  SET
+    clock_out_at    = v_capped_out,
+    early_leave_at  = CASE WHEN v_next_status = 'early_leave' THEN v_capped_out ELSE NULL END,
+    work_minutes    = v_work_minutes,
+    status          = v_next_status,
+    is_manual_close = TRUE,
+    updated_at      = NOW()
+  WHERE id = v_log.id
+  RETURNING * INTO v_result;
+
+  RETURN row_to_json(v_result);
+END;
+$$;
+
+
+-- ── fn_auto_close_stale_session ───────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.fn_auto_close_stale_session(
+  p_user_id   uuid,
+  p_work_date date
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_log        public.attendance_logs;
+  v_result     public.attendance_logs;
+  v_clock_out  TIMESTAMPTZ;
+  v_next_status TEXT;
+BEGIN
+  -- #169: IS DISTINCT FROM 으로 NULL-safe 인가 체크
+  IF auth.uid() IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Unauthorized: You can only auto-close your own stale session';
+  END IF;
+
+  SELECT * INTO v_log
+  FROM public.attendance_logs
+  WHERE user_id = p_user_id AND work_date = p_work_date;
+
+  IF v_log.id IS NULL OR v_log.clock_in_at IS NULL THEN
+    RAISE EXCEPTION 'No clock-in record found for the given date';
+  END IF;
+
+  IF v_log.clock_out_at IS NOT NULL THEN
+    RAISE EXCEPTION 'Session already closed';
+  END IF;
+
+  v_clock_out   := v_log.clock_in_at + INTERVAL '8 hours';
+  v_next_status := CASE WHEN v_log.status = 'late' THEN 'late' ELSE 'present' END;
+
+  UPDATE public.attendance_logs
+  SET
+    clock_out_at    = v_clock_out,
+    early_leave_at  = NULL,
+    work_minutes    = 480,
+    status          = v_next_status,
+    is_manual_close = FALSE,
+    updated_at      = NOW()
+  WHERE id = v_log.id
+  RETURNING * INTO v_result;
+
+  RETURN row_to_json(v_result);
+END;
+$$;


### PR DESCRIPTION
## 요약

attendance stale session 영역의 버그 3종을 한 배치로 수정합니다.

### #169 — `auth.uid() IS DISTINCT FROM` 으로 교체 (보안)

`fn_close_stale_session` / `fn_auto_close_stale_session` 두 RPC의 인가 체크가 `!=` 연산자를 사용하고 있어, `auth.uid()`가 NULL인 미인증 호출 시 `NULL != p_user_id` 가 NULL(falsy)로 평가되어 예외가 발생하지 않는 취약점이 있었습니다. `IS DISTINCT FROM`으로 교체해 NULL-safe 비교를 보장합니다.

### #168 — `work_minutes` 음수 방지 (데이터 무결성)

`fn_close_stale_session`에서 `p_clock_out_at`이 `clock_in_at`보다 이른 시각으로 입력되면 `work_minutes`가 음수가 되는 문제가 있었습니다. 기존 상한 캡(`LEAST`) 앞에 `GREATEST(p_clock_out_at, clock_in_at)` 하한 캡을 추가해 양방향으로 보정합니다.

### #179 — stale session 에러 탐지 범위·메시지 개선 (운영)

- `mapAttendanceError`에 `'unauthorized'` 패턴을 추가 — RPC 인가 실패 시 `UNAUTHENTICATED` 코드를 반환하도록 수정. 기존에는 `UNKNOWN`으로 뭉개져 사용자에게 '근태 처리 중 문제가 발생했어요.'만 표시됐습니다.
- `getAttendanceToday` 쿼리 범위를 `[today, yesterday]` → 최근 7일로 확장하고, `staleRow` 판정 조건을 `work_date === yesterday` → `work_date < today`로 변경. 금요일 출근 후 월요일 복귀 같은 다일(multi-day) stale session도 탐지합니다.

## 변경 파일

| 파일 | 내용 |
|---|---|
| `supabase/migrations/20260417000014_fix_stale_session_auth_and_cap.sql` | #169, #168 SQL 수정 |
| `src/lib/attendance.ts` | #179 `mapAttendanceError` unauthorized 매핑 |
| `src/app/_actions/attendance.ts` | #179 쿼리 범위 7일 확장, staleRow 조건 변경 |
| `src/lib/__tests__/attendance.stale.test.ts` | unauthorized 케이스 3개 추가 |
| `src/app/_actions/__tests__/attendanceToday.stale.test.ts` | resolveActiveRow 동기화, multi-day stale 테스트 2개 추가 |

## 테스트 체크리스트

- [x] `vitest run` — 49개 전체 통과
- [x] ESLint / Prettier 통과
- [ ] Supabase에 마이그레이션 적용 (`supabase db push`)
- [ ] 퇴근 없이 자정 경과 후 stale session 동선 수동 확인
- [ ] 금요일 clock-in → 월요일 접속 시 stale 탐지 확인 (다일 케이스)

Closes #169
Closes #168
Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 미종료 근무 기록 감지 범위 확대: 어제뿐 아니라 더 이전 날짜의 미종료 기록도 감지
  * 세션 만료 오류 메시지 인식 개선: "권한 없음" 관련 오류 더 정확하게 처리
  * 미종료 세션 자동 종료 기능 강화: 오전 6시 이후 자동으로 미종료 근무 기록 처리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->