### PR TITLE
feat: 게시글 상세 하단에 같은 게시판 최근 글 목록 추가 (#184)

### DIFF
--- a/src/app/board/[postId]/page.tsx
+++ b/src/app/board/[postId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound, redirect } from 'next/navigation';
 import { BoardPostView } from '@/components/features/board-post/BoardPostView';
 import { CommentSection } from '@/components/features/board-post/comment/CommentSection';
+import RelatedPosts from '@/components/features/board-post/RelatedPosts';
 import { buildLoginRedirectHref } from '@/lib/boardAccess';
 import { createServerSupabase } from '@/lib/supabase/server';
 import { PostForView } from '@/types/board';
@@ -80,6 +81,25 @@ export default async function BoardPostPage({
 
   const isAuthor = !!user && user.id === post.author_id;
 
+  const relatedQuery = supabase
+    .from('board_posts')
+    .select(
+      'id, topic, title, comment_count, author_name, view_count, created_at'
+    )
+    .eq('scope', post.scope)
+    .is('deleted_at', null)
+    .neq('id', postId)
+    .order('created_at', { ascending: false })
+    .limit(5);
+
+  if (post.scope === 'company') {
+    relatedQuery.eq('board', post.board ?? '');
+  } else {
+    relatedQuery.eq('dept', post.dept ?? '');
+  }
+
+  const { data: relatedPosts } = await relatedQuery;
+
   let isAdmin = false;
   if (user && !isAuthor) {
     const { data: adminRow } = await supabase
@@ -126,6 +146,12 @@ export default async function BoardPostPage({
         postId={postId}
         postAuthorId={post.author_id}
         commentCount={postForView.commentCount}
+      />
+      <RelatedPosts
+        posts={relatedPosts ?? []}
+        scope={post.scope}
+        board={post.board ?? undefined}
+        dept={post.dept ?? undefined}
       />
     </main>
   );

--- a/src/components/features/board-post/RelatedPosts.tsx
+++ b/src/components/features/board-post/RelatedPosts.tsx
@@ -35,7 +35,8 @@ export default function RelatedPosts({
   return (
     <section className="mt-6 px-4 pb-10">
       <h2 className="text-sm font-semibold text-grey-500 mb-1">
-        같은 게시판 최근 글
+        {scope === 'company' ? (board ?? '전사게시판') : (dept ?? '부서게시판')}{' '}
+        최신 글
       </h2>
       <div>
         {posts.map(post => (

--- a/src/components/features/board-post/RelatedPosts.tsx
+++ b/src/components/features/board-post/RelatedPosts.tsx
@@ -1,0 +1,57 @@
+import BoardItem from '@/components/features/board/BoardItem';
+
+interface RelatedPost {
+  id: string;
+  topic: string | null;
+  title: string;
+  comment_count: number | null;
+  author_name: string | null;
+  view_count: number | null;
+  created_at: string;
+}
+
+interface RelatedPostsProps {
+  posts: RelatedPost[];
+  scope: string;
+  board?: string;
+  dept?: string;
+}
+
+export default function RelatedPosts({
+  posts,
+  scope,
+  board,
+  dept,
+}: RelatedPostsProps) {
+  if (posts.length === 0) return null;
+
+  function buildHref(postId: string) {
+    const params = new URLSearchParams({ scope });
+    if (scope === 'company' && board) params.set('board', board);
+    if (scope === 'department' && dept) params.set('dept', dept);
+    return `/board/${postId}?${params.toString()}`;
+  }
+
+  return (
+    <section className="mt-6 px-4 pb-10">
+      <h2 className="text-sm font-semibold text-grey-500 mb-1">
+        같은 게시판 최근 글
+      </h2>
+      <div>
+        {posts.map(post => (
+          <BoardItem
+            key={post.id}
+            id={post.id}
+            topic={post.topic ?? '정보'}
+            title={post.title}
+            commentCount={post.comment_count ?? 0}
+            userName={post.author_name ?? '익명'}
+            viewCount={post.view_count ?? 0}
+            dateCreated={post.created_at}
+            href={buildHref(post.id)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## 요약

게시글 상세 페이지 댓글 섹션 아래에 같은 게시판의 최근 글 5개를 표시합니다.

## 변경 내용

- `board/[postId]/page.tsx`: 현재 글과 동일한 `scope` + `board`(전사) 또는 `dept`(부서) 기준으로 최근 글 5개 fetch. 삭제된 글(`deleted_at IS NOT NULL`)과 현재 글은 제외.
- `RelatedPosts` 컴포넌트 신규 생성: 기존 `BoardItem` 컴포넌트를 재사용해 목록 렌더링. 관련 글이 없으면 섹션 자체를 렌더링하지 않음.
- 각 항목 클릭 시 `scope`, `board`, `dept` 쿼리파람을 보존한 상세 URL로 이동.

## 레이아웃

```
[ 게시글 본문 ]
[ 댓글 섹션  ]
──────────────────
같은 게시판 최근 글
[정보] 제목1   홍길동  👀12  2026-04-15
[공지] 제목2   김철수  👀8   2026-04-14
...
```

## 테스트 체크리스트

- [ ] 전사 게시판 글 상세에서 같은 board 최근 글 표시 확인
- [ ] 부서 게시판 글 상세에서 같은 dept 최근 글 표시 확인
- [ ] 현재 게시글이 목록에서 제외됨 확인
- [ ] 삭제된 글이 목록에 포함되지 않음 확인
- [ ] 같은 게시판 글이 5개 미만일 때 그 수만큼만 표시 확인
- [ ] 같은 게시판 글이 0개일 때 섹션이 표시되지 않음 확인
- [ ] 항목 클릭 시 올바른 상세 URL로 이동 확인

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)